### PR TITLE
fix: pandas and pydantic deprecations

### DIFF
--- a/src/gems/model/parsing.py
+++ b/src/gems/model/parsing.py
@@ -13,7 +13,7 @@ import typing
 from dataclasses import dataclass
 from typing import List, Optional
 
-from pydantic import Field, ValidationError
+from pydantic import ConfigDict, Field, ValidationError
 from yaml import safe_load
 
 from gems.utils import ModifiedBaseModel
@@ -41,8 +41,7 @@ class InputVariable(ModifiedBaseModel):
     upper_bound: Optional[str] = None
     variable_type: str = "continuous"
 
-    class Config(ModifiedBaseModel.Config):
-        coerce_numbers_to_str = True
+    model_config = ConfigDict(**ModifiedBaseModel.model_config, coerce_numbers_to_str=True)
 
 
 class InputConstraint(ModifiedBaseModel):

--- a/src/gems/model/parsing.py
+++ b/src/gems/model/parsing.py
@@ -41,7 +41,9 @@ class InputVariable(ModifiedBaseModel):
     upper_bound: Optional[str] = None
     variable_type: str = "continuous"
 
-    model_config = ConfigDict(**ModifiedBaseModel.model_config, coerce_numbers_to_str=True)
+    model_config = ConfigDict(
+        **ModifiedBaseModel.model_config, coerce_numbers_to_str=True
+    )
 
 
 class InputConstraint(ModifiedBaseModel):

--- a/src/gems/utils.py
+++ b/src/gems/utils.py
@@ -83,4 +83,6 @@ def _to_kebab(snake: str) -> str:
 
 
 class ModifiedBaseModel(BaseModel):
-    model_config = ConfigDict(alias_generator=_to_kebab, extra="forbid", populate_by_name=True)
+    model_config = ConfigDict(
+        alias_generator=_to_kebab, extra="forbid", populate_by_name=True
+    )

--- a/src/gems/utils.py
+++ b/src/gems/utils.py
@@ -17,7 +17,7 @@ import json
 import pathlib
 from typing import Any, Callable, Dict, Optional, TypeVar
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 T = TypeVar("T")
 K = TypeVar("K")
@@ -83,7 +83,4 @@ def _to_kebab(snake: str) -> str:
 
 
 class ModifiedBaseModel(BaseModel):
-    class Config:
-        alias_generator = _to_kebab
-        extra = "forbid"
-        populate_by_name = True
+    model_config = ConfigDict(alias_generator=_to_kebab, extra="forbid", populate_by_name=True)

--- a/tests/e2e/functional/test_performance.py
+++ b/tests/e2e/functional/test_performance.py
@@ -33,9 +33,7 @@ from tests.e2e.functional.libs.standard import (
 def generate_scalar_matrix_data(
     value: float, horizon: int, scenarios: int
 ) -> TimeScenarioSeriesData:
-    data = pd.DataFrame(index=range(horizon), columns=range(scenarios))
-
-    data.fillna(value, inplace=True)
+    data = pd.DataFrame(value, index=range(horizon), columns=range(scenarios))
 
     return TimeScenarioSeriesData(time_scenario_series=data)
 

--- a/tests/e2e/functional/test_stochastic.py
+++ b/tests/e2e/functional/test_stochastic.py
@@ -29,9 +29,7 @@ from tests.e2e.functional.libs.standard import (
 def generate_scalar_matrix_data(
     value: float, horizon: int, scenarios: int
 ) -> TimeScenarioSeriesData:
-    data = pd.DataFrame(index=range(horizon), columns=range(scenarios))
-
-    data.fillna(value, inplace=True)
+    data = pd.DataFrame(value, index=range(horizon), columns=range(scenarios))
 
     return TimeScenarioSeriesData(time_scenario_series=data)
 

--- a/tests/e2e/models/poc-various-models/test_short_term_storage_complex.py
+++ b/tests/e2e/models/poc-various-models/test_short_term_storage_complex.py
@@ -30,7 +30,7 @@ def generate_data(
     for scenario in range(scenarios):
         # Create a column name based on the scenario number
         column_name = f"scenario_{scenario}"
-        data[column_name] = 0  # Initialize the column with zeros
+        data[column_name] = 0.0  # Initialize the column with zeros
 
         for absolute_timestep in range(horizon):
             if absolute_timestep == 0:

--- a/tests/unittests/simulation/test_simulation_table_mock.py
+++ b/tests/unittests/simulation/test_simulation_table_mock.py
@@ -123,19 +123,19 @@ def test_simulation_table_builder_manual(tmp_path):
         },
         {
             SimulationColumns.BLOCK: 1,
-            SimulationColumns.COMPONENT: pd.NA,
+            SimulationColumns.COMPONENT: None,
             SimulationColumns.OUTPUT: "objective-value",
-            SimulationColumns.ABSOLUTE_TIME_INDEX: pd.NA,
-            SimulationColumns.BLOCK_TIME_INDEX: pd.NA,
-            SimulationColumns.SCENARIO_INDEX: pd.NA,
+            SimulationColumns.ABSOLUTE_TIME_INDEX: None,
+            SimulationColumns.BLOCK_TIME_INDEX: None,
+            SimulationColumns.SCENARIO_INDEX: None,
             SimulationColumns.VALUE: 42.0,
-            SimulationColumns.BASIS_STATUS: pd.NA,
+            SimulationColumns.BASIS_STATUS: None,
         },
     ]
-    expected_df = pd.DataFrame(expected_rows).fillna(pd.NA)
+    expected_df = pd.DataFrame(expected_rows)
 
     pd.testing.assert_frame_equal(
-        df.reset_index(drop=True).fillna(pd.NA),
+        df.reset_index(drop=True),
         expected_df,
         check_dtype=False,
     )


### PR DESCRIPTION
Fix pandas and pydantic deprecation warnings                                                                                                                                                                             
                                                            
  - Migrate ModifiedBaseModel and InputVariable from deprecated class Config to model_config = ConfigDict(...)                                                                                                             
  - Fix pandas FutureWarnings in tests by creating DataFrames with explicit dtype instead of using fillna on object arrays  
  
  The first point fix warnings that were printed in the ViewBuilder tests