### PR TITLE
Implement time shift support in expression evaluation

### DIFF
--- a/src/gems/expression/evaluate.py
+++ b/src/gems/expression/evaluate.py
@@ -13,7 +13,7 @@
 import math
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Dict
+from typing import Dict, Iterable
 
 from gems.expression.expression import (
     AllTimeSumNode,
@@ -51,24 +51,25 @@ class ValueProvider(ABC):
     """
 
     @abstractmethod
-    def get_variable_value(self, name: str) -> float:
-        ...
+    def get_variable_value(self, name: str) -> float: ...
 
     @abstractmethod
-    def get_parameter_value(self, name: str) -> float:
-        ...
+    def get_parameter_value(self, name: str) -> float: ...
 
     @abstractmethod
-    def get_component_variable_value(self, component_id: str, name: str) -> float:
-        ...
+    def get_component_variable_value(self, component_id: str, name: str) -> float: ...
 
     @abstractmethod
-    def get_component_parameter_value(self, component_id: str, name: str) -> float:
-        ...
+    def get_component_parameter_value(self, component_id: str, name: str) -> float: ...
 
     @abstractmethod
-    def shift(self, offset: int) -> "ValueProvider":
-        ...
+    def shift(self, offset: int) -> "ValueProvider": ...
+
+    @abstractmethod
+    def eval_at(self, timestep: int) -> "ValueProvider": ...
+
+    @abstractmethod
+    def all_block_timesteps(self) -> Iterable[int]: ...
 
 
 @dataclass(frozen=True)
@@ -95,6 +96,12 @@ class EvaluationContext(ValueProvider):
 
     def shift(self, offset: int) -> "ValueProvider":
         return self
+
+    def eval_at(self, timestep: int) -> "ValueProvider":
+        return self
+
+    def all_block_timesteps(self) -> Iterable[int]:
+        return range(1)
 
 
 @dataclass(frozen=True)
@@ -135,13 +142,22 @@ class EvaluationVisitor(ExpressionVisitorOperations[float]):
         return visit(node.operand, EvaluationVisitor(self.context.shift(shift)))
 
     def time_eval(self, node: TimeEvalNode) -> float:
-        raise NotImplementedError()
+        timestep = int(visit(node.eval_time, self))
+        return visit(node.operand, EvaluationVisitor(self.context.eval_at(timestep)))
 
     def time_sum(self, node: TimeSumNode) -> float:
-        raise NotImplementedError()
+        from_shift = int(visit(node.from_time, self))
+        to_shift = int(visit(node.to_time, self))
+        return sum(
+            visit(node.operand, EvaluationVisitor(self.context.shift(t)))
+            for t in range(from_shift, to_shift + 1)
+        )
 
     def all_time_sum(self, node: AllTimeSumNode) -> float:
-        raise NotImplementedError()
+        return sum(
+            visit(node.operand, EvaluationVisitor(self.context.eval_at(t)))
+            for t in self.context.all_block_timesteps()
+        )
 
     def scenario_operator(self, node: ScenarioOperatorNode) -> float:
         raise NotImplementedError()

--- a/src/gems/expression/evaluate.py
+++ b/src/gems/expression/evaluate.py
@@ -66,6 +66,10 @@ class ValueProvider(ABC):
     def get_component_parameter_value(self, component_id: str, name: str) -> float:
         ...
 
+    @abstractmethod
+    def shift(self, offset: int) -> "ValueProvider":
+        ...
+
 
 @dataclass(frozen=True)
 class EvaluationContext(ValueProvider):
@@ -88,6 +92,9 @@ class EvaluationContext(ValueProvider):
 
     def get_component_parameter_value(self, component_id: str, name: str) -> float:
         raise NotImplementedError()
+
+    def shift(self, offset: int) -> "ValueProvider":
+        return self
 
 
 @dataclass(frozen=True)
@@ -124,7 +131,8 @@ class EvaluationVisitor(ExpressionVisitorOperations[float]):
         raise ValueError("Should not reach here.")
 
     def time_shift(self, node: TimeShiftNode) -> float:
-        raise NotImplementedError()
+        shift = int(visit(node.time_shift, self))
+        return visit(node.operand, EvaluationVisitor(self.context.shift(shift)))
 
     def time_eval(self, node: TimeEvalNode) -> float:
         raise NotImplementedError()

--- a/src/gems/simulation/extra_output.py
+++ b/src/gems/simulation/extra_output.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Iterable, Optional
 
 from gems.expression.evaluate import ValueProvider
 from gems.simulation.optimization import OptimizationProblem
@@ -94,3 +94,9 @@ class ExtraOutputValueProvider(ValueProvider):
 
     def shift(self, offset: int) -> "ValueProvider":
         return self
+
+    def eval_at(self, timestep: int) -> "ValueProvider":
+        return self
+
+    def all_block_timesteps(self) -> Iterable[int]:
+        return range(1)

--- a/src/gems/simulation/extra_output.py
+++ b/src/gems/simulation/extra_output.py
@@ -91,3 +91,6 @@ class ExtraOutputValueProvider(ValueProvider):
 
     def get_component_parameter_value(self, component_id: str, name: str) -> float:
         return self.context[name]
+
+    def shift(self, offset: int) -> "ValueProvider":
+        return self

--- a/src/gems/simulation/optimization.py
+++ b/src/gems/simulation/optimization.py
@@ -103,6 +103,10 @@ def _make_value_provider(
                 "Parameter must be associated to its component before resolution."
             )
 
+        def shift(self, offset: int) -> ValueProvider:
+            new_timestep = (block_timestep + offset) if block_timestep is not None else None
+            return _make_value_provider(context, new_timestep, scenario)
+
     return Impl()
 
 
@@ -414,6 +418,9 @@ class OptimizationContext:
                 raise ValueError(
                     "Parameter must be associated to its component before resolution."
                 )
+
+            def shift(self, offset: int) -> ValueProvider:
+                return self
 
         return Impl()
 

--- a/src/gems/simulation/optimization.py
+++ b/src/gems/simulation/optimization.py
@@ -104,8 +104,16 @@ def _make_value_provider(
             )
 
         def shift(self, offset: int) -> ValueProvider:
-            new_timestep = (block_timestep + offset) if block_timestep is not None else None
+            new_timestep = (
+                (block_timestep + offset) if block_timestep is not None else None
+            )
             return _make_value_provider(context, new_timestep, scenario)
+
+        def eval_at(self, timestep: int) -> ValueProvider:
+            return _make_value_provider(context, timestep, scenario)
+
+        def all_block_timesteps(self) -> Iterable[int]:
+            return range(context.block_length())
 
     return Impl()
 
@@ -421,6 +429,12 @@ class OptimizationContext:
 
             def shift(self, offset: int) -> ValueProvider:
                 return self
+
+            def eval_at(self, timestep: int) -> ValueProvider:
+                return self
+
+            def all_block_timesteps(self) -> Iterable[int]:
+                return range(1)
 
         return Impl()
 
@@ -896,11 +910,9 @@ def fusion_problems(
                 root_var = root_vars[var.name()]
                 root_var.SetLb(var.lb())
                 root_var.SetUb(var.ub())
-                root_master.context._solver_variables[
-                    var.name()
-                ].is_in_objective = context._solver_variables[
-                    var.name()
-                ].is_in_objective
+                root_master.context._solver_variables[var.name()].is_in_objective = (
+                    context._solver_variables[var.name()].is_in_objective
+                )
 
             for cstr in master.solver.constraints():
                 coeff = cstr.GetCoefficient(var)

--- a/tests/unittests/expressions/visitor/test_evaluation.py
+++ b/tests/unittests/expressions/visitor/test_evaluation.py
@@ -11,7 +11,7 @@
 # This file is part of the Antares project.
 
 from dataclasses import dataclass, field
-from typing import Dict
+from typing import Dict, Iterable
 
 import pytest
 
@@ -70,6 +70,12 @@ class ComponentEvaluationContext(ValueProvider):
 
     def shift(self, offset: int) -> "ValueProvider":
         return self
+
+    def eval_at(self, timestep: int) -> "ValueProvider":
+        return self
+
+    def all_block_timesteps(self) -> Iterable[int]:
+        return range(1)
 
 
 def test_comp_parameter() -> None:

--- a/tests/unittests/expressions/visitor/test_evaluation.py
+++ b/tests/unittests/expressions/visitor/test_evaluation.py
@@ -68,6 +68,9 @@ class ComponentEvaluationContext(ValueProvider):
     def get_component_parameter_value(self, component_id: str, name: str) -> float:
         return self.parameters[comp_key(component_id, name)]
 
+    def shift(self, offset: int) -> "ValueProvider":
+        return self
+
 
 def test_comp_parameter() -> None:
     add_node = AdditionNode([LiteralNode(1), ComponentVariableNode("comp1", "x")])


### PR DESCRIPTION
## Summary
This PR adds support for time shifting in expression evaluation by introducing a `shift()` method to the `ValueProvider` interface and implementing time shift evaluation in the expression visitor.

## Key Changes
- **Abstract method addition**: Added abstract `shift(offset: int)` method to `ValueProvider` interface to enable temporal offset operations
- **Time shift evaluation**: Implemented `time_shift()` method in `EvaluationVisitor` to evaluate time-shifted expressions by computing the shift offset and creating a new evaluation context with the shifted timestep
- **Implementation across providers**: Added `shift()` implementations to all `ValueProvider` implementations:
  - `EvaluationContext`: Returns self (no-op for base context)
  - `_make_value_provider` in optimization.py: Creates new provider with adjusted timestep
  - Fallback implementation in optimization.py: Returns self (no-op)
  - `ExtraOutputValueProvider`: Returns self (no-op)
- **Test coverage**: Updated test mock to implement the new `shift()` method

## Implementation Details
The time shift evaluation works by:
1. Evaluating the time shift expression to get an integer offset
2. Creating a new `EvaluationVisitor` with a shifted context (via `context.shift(offset)`)
3. Evaluating the operand within this shifted context

This allows expressions to reference values at different timesteps during evaluation.

https://claude.ai/code/session_011kQZpMxUpTSdBHFe3F7unJ