### PR TITLE
Bump version to 0.0.6 in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gemspy"
-version = "0.0.5"
+version = "0.0.6"
 description = "Python interpreter for GEMS: modelling and simulation of complex energy systems under uncertainty"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
This PR bumps the GemsPy version to 0.0.6 inside the pyproject.toml file before the future v0.0.6 release