### PR TITLE
Add Polars-backed lazy parquet data structures with pluggable executor and materialization strategies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "highspy>=1.14",
     "pandas>=2.2",
     "attrs>=26.0",
+    "polars>=1.0",
 ]
 classifiers = [
    #    Classifiers here: https://pypi.org/classifiers/

--- a/src/gems/optim_config/parsing.py
+++ b/src/gems/optim_config/parsing.py
@@ -81,6 +81,7 @@ class ResolutionConfig(ModifiedBaseModel):
     mode: ResolutionMode = ResolutionMode.FRONTAL
     block_length: Optional[int] = None
     block_overlap: int = 0
+    blocks_per_batch: int = 1
 
     @model_validator(mode="after")
     def _block_length_required_for_windowed_modes(self) -> "ResolutionConfig":

--- a/src/gems/optim_config/parsing.py
+++ b/src/gems/optim_config/parsing.py
@@ -202,9 +202,7 @@ def _check_id_existence(
 ) -> None:
     for variable_config in decomposition.variables:
         if variable_config.id not in model.variables:
-            errors.append(
-                f"Variable '{variable_config.id}' not found in model '{model_config_id}'"
-            )
+            errors.append(f"Variable '{variable_config.id}' not found in model '{model_config_id}'")
     for constraint_config in decomposition.constraints:
         if (
             constraint_config.id not in model.constraints
@@ -229,10 +227,7 @@ def _check_master_variables_not_time_dependent(
 ) -> None:
     """Variables assigned to master or master-and-subproblems must not depend on time."""
     for variable_config in decomposition.variables:
-        if (
-            variable_config.location in _MASTER_LOCS
-            and variable_config.id in model.variables
-        ):
+        if variable_config.location in _MASTER_LOCS and variable_config.id in model.variables:
             if model.variables[variable_config.id].structure.time:
                 errors.append(
                     f"Variable '{variable_config.id}' in model '{model_config_id}' is time-dependent "
@@ -251,8 +246,7 @@ def _check_master_constraints_use_master_variables(
     master_var_ids = {
         variable_config.id
         for variable_config in decomposition.variables
-        if variable_config.location in _MASTER_LOCS
-        and variable_config.id in model.variables
+        if variable_config.location in _MASTER_LOCS and variable_config.id in model.variables
     }
     for constraint_config in decomposition.constraints:
         if constraint_config.location == ElementLocation.MASTER:
@@ -279,8 +273,7 @@ def _check_master_objectives_use_master_variables(
     master_var_ids = {
         variable_config.id
         for variable_config in decomposition.variables
-        if variable_config.location in _MASTER_LOCS
-        and variable_config.id in model.variables
+        if variable_config.location in _MASTER_LOCS and variable_config.id in model.variables
     }
     obj_contribs = model.objective_contributions or {}
     for obj_config in decomposition.objective_contributions:
@@ -331,6 +324,4 @@ def validate_optim_config(config: OptimConfig, system: "System") -> None:
                 )
 
     if errors:
-        raise ValueError(
-            f"Errors in optim config file:\n" + "\n".join(f"  - {e}" for e in errors)
-        )
+        raise ValueError(f"Errors in optim config file:\n" + "\n".join(f"  - {e}" for e in errors))

--- a/src/gems/optim_config/parsing.py
+++ b/src/gems/optim_config/parsing.py
@@ -81,7 +81,6 @@ class ResolutionConfig(ModifiedBaseModel):
     mode: ResolutionMode = ResolutionMode.FRONTAL
     block_length: Optional[int] = None
     block_overlap: int = 0
-    blocks_per_batch: int = 1
 
     @model_validator(mode="after")
     def _block_length_required_for_windowed_modes(self) -> "ResolutionConfig":

--- a/src/gems/session/__init__.py
+++ b/src/gems/session/__init__.py
@@ -10,6 +10,6 @@
 #
 # This file is part of the Antares project.
 
-from .session import SimulationSession
+from .session import MaterializationStrategy, SimulationSession
 
-__all__ = ["SimulationSession"]
+__all__ = ["MaterializationStrategy", "SimulationSession"]

--- a/src/gems/session/session.py
+++ b/src/gems/session/session.py
@@ -10,6 +10,7 @@
 #
 # This file is part of the Antares project.
 
+from concurrent.futures import Executor
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
@@ -33,6 +34,7 @@ from gems.study.study import Study
 class SimulationSession:
     study: Study
     optim_config: OptimConfig
+    executor: Optional[Executor] = None
     run_id: str = field(default_factory=lambda: str(uuid4()))
     output_dir: Optional[Path] = None
 
@@ -106,15 +108,15 @@ class SimulationSession:
         cfg = self.optim_config.resolution
         block_length: int = cfg.block_length  # type: ignore[assignment]
 
-        tables: List[SimulationTable] = []
+        work_items: List[Tuple[TimeBlock, List[int]]] = []
         for scenario_id in self.scenario_ids:
             starts = range(
                 self.optim_config.time_scope.first_time_step,
                 self.optim_config.time_scope.last_time_step + 1,
                 block_length,
             )
-            blocks = [
-                TimeBlock(
+            for i, t in enumerate(starts):
+                block = TimeBlock(
                     i,
                     list(
                         range(
@@ -126,11 +128,19 @@ class SimulationSession:
                         )
                     ),
                 )
-                for i, t in enumerate(starts)
+                work_items.append((block, [scenario_id]))
+
+        if self.executor is not None:
+            futures = [
+                self.executor.submit(self._run_block, block, scenario_ids)
+                for block, scenario_ids in work_items
             ]
-            for block in blocks:
-                _, table = self._run_block(block, scenario_ids=[scenario_id])
-                tables.append(table)
+            tables = [f.result()[1] for f in futures]
+        else:
+            tables = [
+                self._run_block(block, scenario_ids)[1]
+                for block, scenario_ids in work_items
+            ]
 
         return self._reduce(tables)
 

--- a/src/gems/session/session.py
+++ b/src/gems/session/session.py
@@ -77,12 +77,11 @@ class SimulationSession:
         block_length: int = cfg.block_length  # type: ignore[assignment]
         block_overlap: int = cfg.block_overlap
 
-        tables: List[SimulationTable] = []
-        for scenario_id in self.scenario_ids:
+        def _run_one_scenario_sequential(scenario_id: int) -> SimulationTable:
             t_start = self.optim_config.time_scope.first_time_step
             block_id = 0
             carry_over: Dict[Tuple[str, str], xr.DataArray] = {}
-
+            block_tables: List[SimulationTable] = []
             while t_start < self.optim_config.time_scope.last_time_step:
                 end = min(
                     t_start + block_length,
@@ -95,52 +94,57 @@ class SimulationSession:
                     scenario_ids=[scenario_id],
                     initial_values=carry_over or None,
                 )
-                tables.append(table)
+                block_tables.append(table)
                 carry_over = self._extract_carry_over(
                     problem, local_index=len(timesteps) - 1
                 )
                 t_start += block_length - block_overlap
                 block_id += 1
+            return self._reduce(block_tables)
 
-        return self._reduce(tables)
+        if self.executor is not None:
+            futures = [
+                self.executor.submit(_run_one_scenario_sequential, sid)
+                for sid in self.scenario_ids
+            ]
+            scenario_tables = [f.result() for f in futures]
+        else:
+            scenario_tables = [
+                _run_one_scenario_sequential(sid) for sid in self.scenario_ids
+            ]
+
+        return self._reduce(scenario_tables)
 
     def _run_parallel(self) -> SimulationTable:
         cfg = self.optim_config.resolution
         block_length: int = cfg.block_length  # type: ignore[assignment]
+        blocks_per_batch: int = cfg.blocks_per_batch
 
-        work_items: List[Tuple[TimeBlock, List[int]]] = []
+        t_end = self.optim_config.time_scope.last_time_step + 1
+        all_block_starts = list(
+            range(self.optim_config.time_scope.first_time_step, t_end, block_length)
+        )
+
+        # Build batches: each batch is a list of independent (TimeBlock, scenario_ids) pairs
+        # that will be executed on the same worker.
+        batches: List[List[Tuple[TimeBlock, List[int]]]] = []
         for scenario_id in self.scenario_ids:
-            starts = range(
-                self.optim_config.time_scope.first_time_step,
-                self.optim_config.time_scope.last_time_step + 1,
-                block_length,
-            )
-            for i, t in enumerate(starts):
-                block = TimeBlock(
-                    i,
-                    list(
-                        range(
-                            t,
-                            min(
-                                t + block_length,
-                                self.optim_config.time_scope.last_time_step + 1,
-                            ),
-                        )
-                    ),
-                )
-                work_items.append((block, [scenario_id]))
+            for i in range(0, len(all_block_starts), blocks_per_batch):
+                batch = []
+                for block_idx, bs in enumerate(
+                    all_block_starts[i : i + blocks_per_batch], start=i
+                ):
+                    timesteps = list(range(bs, min(bs + block_length, t_end)))
+                    batch.append((TimeBlock(block_idx, timesteps), [scenario_id]))
+                batches.append(batch)
 
         if self.executor is not None:
             futures = [
-                self.executor.submit(self._run_block, block, scenario_ids)
-                for block, scenario_ids in work_items
+                self.executor.submit(self._run_batch, batch) for batch in batches
             ]
-            tables = [f.result()[1] for f in futures]
+            tables = [t for f in futures for t in f.result()]
         else:
-            tables = [
-                self._run_block(block, scenario_ids)[1]
-                for block, scenario_ids in work_items
-            ]
+            tables = [t for batch in batches for t in self._run_batch(batch)]
 
         return self._reduce(tables)
 
@@ -211,6 +215,12 @@ class SimulationSession:
             problem, scenario_ids_remap=scenario_ids, table_id=self.run_id
         )
         return problem, table
+
+    def _run_batch(
+        self, batch: List[Tuple[TimeBlock, List[int]]]
+    ) -> List[SimulationTable]:
+        """Run a list of independent (block, scenario_ids) pairs on one worker."""
+        return [self._run_block(block, sids)[1] for block, sids in batch]
 
     def _reduce(self, tables: List[SimulationTable]) -> SimulationTable:
         """REDUCE: merge SimulationTables from one scenario's blocks into one."""

--- a/src/gems/session/session.py
+++ b/src/gems/session/session.py
@@ -11,7 +11,7 @@
 # This file is part of the Antares project.
 
 from concurrent.futures import Executor
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 from uuid import uuid4
@@ -35,6 +35,7 @@ class SimulationSession:
     study: Study
     optim_config: OptimConfig
     executor: Optional[Executor] = None
+    materialize_per_worker: bool = False
     run_id: str = field(default_factory=lambda: str(uuid4()))
     output_dir: Optional[Path] = None
 
@@ -78,6 +79,10 @@ class SimulationSession:
         block_overlap: int = cfg.block_overlap
 
         def _run_one_scenario_sequential(scenario_id: int) -> SimulationTable:
+            effective_study = self.study
+            if self.materialize_per_worker:
+                mat_db = self.study.database.materialize([scenario_id])
+                effective_study = replace(self.study, database=mat_db)
             t_start = self.optim_config.time_scope.first_time_step
             block_id = 0
             carry_over: Dict[Tuple[str, str], xr.DataArray] = {}
@@ -93,6 +98,7 @@ class SimulationSession:
                     block,
                     scenario_ids=[scenario_id],
                     initial_values=carry_over or None,
+                    study=effective_study,
                 )
                 block_tables.append(table)
                 carry_over = self._extract_carry_over(problem, local_index=len(timesteps) - 1)
@@ -179,6 +185,7 @@ class SimulationSession:
         block: TimeBlock,
         scenario_ids: List[int],
         initial_values: Optional[Dict[Tuple[str, str], xr.DataArray]] = None,
+        study: Optional[Study] = None,
     ) -> Tuple[OptimizationProblem, SimulationTable]:
         """MAP: build and solve one block, then convert to a SimulationTable.
 
@@ -187,8 +194,9 @@ class SimulationSession:
         scenario_ids_remap equals scenario_ids because the list of MC scenario IDs
         IS the mapping from internal 0-based position to actual MC identifier.
         """
+        effective_study = study if study is not None else self.study
         problem = build_problem(
-            self.study,
+            effective_study,
             block,
             scenario_ids,
             optim_config=self.optim_config,
@@ -206,7 +214,12 @@ class SimulationSession:
 
     def _run_batch(self, batch: List[Tuple[TimeBlock, List[int]]]) -> List[SimulationTable]:
         """Run a list of independent (block, scenario_ids) pairs on one worker."""
-        return [self._run_block(block, sids)[1] for block, sids in batch]
+        study = self.study
+        if self.materialize_per_worker:
+            scenario_id = batch[0][1][0]
+            mat_db = study.database.materialize([scenario_id])
+            study = replace(study, database=mat_db)
+        return [self._run_block(block, sids, study=study)[1] for block, sids in batch]
 
     def _reduce(self, tables: List[SimulationTable]) -> SimulationTable:
         """REDUCE: merge SimulationTables from one scenario's blocks into one."""

--- a/src/gems/session/session.py
+++ b/src/gems/session/session.py
@@ -115,10 +115,9 @@ class SimulationSession:
 
         return self._reduce(scenario_tables)
 
-    def _run_parallel(self) -> SimulationTable:
+    def _run_parallel(self, blocks_per_batch: int = 1) -> SimulationTable:
         cfg = self.optim_config.resolution
         block_length: int = cfg.block_length  # type: ignore[assignment]
-        blocks_per_batch: int = cfg.blocks_per_batch
 
         t_end = self.optim_config.time_scope.last_time_step + 1
         all_block_starts = list(

--- a/src/gems/session/session.py
+++ b/src/gems/session/session.py
@@ -95,23 +95,18 @@ class SimulationSession:
                     initial_values=carry_over or None,
                 )
                 block_tables.append(table)
-                carry_over = self._extract_carry_over(
-                    problem, local_index=len(timesteps) - 1
-                )
+                carry_over = self._extract_carry_over(problem, local_index=len(timesteps) - 1)
                 t_start += block_length - block_overlap
                 block_id += 1
             return self._reduce(block_tables)
 
         if self.executor is not None:
             futures = [
-                self.executor.submit(_run_one_scenario_sequential, sid)
-                for sid in self.scenario_ids
+                self.executor.submit(_run_one_scenario_sequential, sid) for sid in self.scenario_ids
             ]
             scenario_tables = [f.result() for f in futures]
         else:
-            scenario_tables = [
-                _run_one_scenario_sequential(sid) for sid in self.scenario_ids
-            ]
+            scenario_tables = [_run_one_scenario_sequential(sid) for sid in self.scenario_ids]
 
         return self._reduce(scenario_tables)
 
@@ -130,17 +125,13 @@ class SimulationSession:
         for scenario_id in self.scenario_ids:
             for i in range(0, len(all_block_starts), blocks_per_batch):
                 batch = []
-                for block_idx, bs in enumerate(
-                    all_block_starts[i : i + blocks_per_batch], start=i
-                ):
+                for block_idx, bs in enumerate(all_block_starts[i : i + blocks_per_batch], start=i):
                     timesteps = list(range(bs, min(bs + block_length, t_end)))
                     batch.append((TimeBlock(block_idx, timesteps), [scenario_id]))
                 batches.append(batch)
 
         if self.executor is not None:
-            futures = [
-                self.executor.submit(self._run_batch, batch) for batch in batches
-            ]
+            futures = [self.executor.submit(self._run_batch, batch) for batch in batches]
             tables = [t for f in futures for t in f.result()]
         else:
             tables = [t for batch in batches for t in self._run_batch(batch)]
@@ -171,9 +162,7 @@ class SimulationSession:
         )
 
         if decomposed.master is not None and self.output_dir is not None:
-            dump_couplings(
-                build_couplings(decomposed, self.optim_config), self.output_dir
-            )
+            dump_couplings(build_couplings(decomposed, self.optim_config), self.output_dir)
             BendersRunner(emplacement=self.output_dir).run()
         else:
             raise RuntimeError(
@@ -215,9 +204,7 @@ class SimulationSession:
         )
         return problem, table
 
-    def _run_batch(
-        self, batch: List[Tuple[TimeBlock, List[int]]]
-    ) -> List[SimulationTable]:
+    def _run_batch(self, batch: List[Tuple[TimeBlock, List[int]]]) -> List[SimulationTable]:
         """Run a list of independent (block, scenario_ids) pairs on one worker."""
         return [self._run_block(block, sids)[1] for block, sids in batch]
 

--- a/src/gems/session/session.py
+++ b/src/gems/session/session.py
@@ -12,6 +12,7 @@
 
 from concurrent.futures import Executor
 from dataclasses import dataclass, field, replace
+from enum import Enum
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 from uuid import uuid4
@@ -30,12 +31,18 @@ from gems.study.folder import load_study
 from gems.study.study import Study
 
 
+class MaterializationStrategy(str, Enum):
+    NONE = "none"
+    UPFRONT = "upfront"
+    PER_WORKER = "per-worker"
+
+
 @dataclass
 class SimulationSession:
     study: Study
     optim_config: OptimConfig
     executor: Optional[Executor] = None
-    materialize_per_worker: bool = False
+    materialization: MaterializationStrategy = MaterializationStrategy.NONE
     run_id: str = field(default_factory=lambda: str(uuid4()))
     output_dir: Optional[Path] = None
 
@@ -78,11 +85,16 @@ class SimulationSession:
         block_length: int = cfg.block_length  # type: ignore[assignment]
         block_overlap: int = cfg.block_overlap
 
+        base_study = self.study
+        if self.materialization == MaterializationStrategy.UPFRONT:
+            mat_db = self.study.database.materialize(self.scenario_ids)
+            base_study = replace(self.study, database=mat_db)
+
         def _run_one_scenario_sequential(scenario_id: int) -> SimulationTable:
-            effective_study = self.study
-            if self.materialize_per_worker:
-                mat_db = self.study.database.materialize([scenario_id])
-                effective_study = replace(self.study, database=mat_db)
+            effective_study = base_study
+            if self.materialization == MaterializationStrategy.PER_WORKER:
+                mat_db = base_study.database.materialize([scenario_id])
+                effective_study = replace(base_study, database=mat_db)
             t_start = self.optim_config.time_scope.first_time_step
             block_id = 0
             carry_over: Dict[Tuple[str, str], xr.DataArray] = {}
@@ -120,6 +132,11 @@ class SimulationSession:
         cfg = self.optim_config.resolution
         block_length: int = cfg.block_length  # type: ignore[assignment]
 
+        base_study = self.study
+        if self.materialization == MaterializationStrategy.UPFRONT:
+            mat_db = self.study.database.materialize(self.scenario_ids)
+            base_study = replace(self.study, database=mat_db)
+
         t_end = self.optim_config.time_scope.last_time_step + 1
         all_block_starts = list(
             range(self.optim_config.time_scope.first_time_step, t_end, block_length)
@@ -137,10 +154,10 @@ class SimulationSession:
                 batches.append(batch)
 
         if self.executor is not None:
-            futures = [self.executor.submit(self._run_batch, batch) for batch in batches]
+            futures = [self.executor.submit(self._run_batch, batch, base_study) for batch in batches]
             tables = [t for f in futures for t in f.result()]
         else:
-            tables = [t for batch in batches for t in self._run_batch(batch)]
+            tables = [t for batch in batches for t in self._run_batch(batch, base_study)]
 
         return self._reduce(tables)
 
@@ -212,10 +229,9 @@ class SimulationSession:
         )
         return problem, table
 
-    def _run_batch(self, batch: List[Tuple[TimeBlock, List[int]]]) -> List[SimulationTable]:
+    def _run_batch(self, batch: List[Tuple[TimeBlock, List[int]]], study: Study) -> List[SimulationTable]:
         """Run a list of independent (block, scenario_ids) pairs on one worker."""
-        study = self.study
-        if self.materialize_per_worker:
+        if self.materialization == MaterializationStrategy.PER_WORKER:
             scenario_id = batch[0][1][0]
             mat_db = study.database.materialize([scenario_id])
             study = replace(study, database=mat_db)

--- a/src/gems/study/__init__.py
+++ b/src/gems/study/__init__.py
@@ -13,6 +13,9 @@
 from .data import (
     ConstantData,
     DataBase,
+    LazyScenarioSeriesData,
+    LazyTimeScenarioSeriesData,
+    LazyTimeSeriesData,
     ScenarioIndex,
     ScenarioSeriesData,
     TimeIndex,

--- a/src/gems/study/__init__.py
+++ b/src/gems/study/__init__.py
@@ -16,6 +16,7 @@ from .data import (
     LazyScenarioSeriesData,
     LazyTimeScenarioSeriesData,
     LazyTimeSeriesData,
+    MaterializedTimeScenarioSeriesData,
     ScenarioIndex,
     ScenarioSeriesData,
     TimeIndex,

--- a/src/gems/study/data.py
+++ b/src/gems/study/data.py
@@ -205,7 +205,7 @@ class LazyScenarioSeriesData(AbstractDataStructure):
         return result
 
     def materialize(self) -> "ScenarioSeriesData":
-        row = pl.scan_parquet(self.uri).collect().to_numpy()[0]
+        row = pl.scan_parquet(self.uri).head(1).collect().to_numpy()[0]
         return ScenarioSeriesData(row)
 
     def check_requirement(self, time: bool, scenario: bool) -> bool:

--- a/src/gems/study/data.py
+++ b/src/gems/study/data.py
@@ -195,11 +195,10 @@ class LazyScenarioSeriesData(AbstractDataStructure):
     ) -> np.ndarray:
         if scenario is None:
             raise KeyError("Scenario series data requires a scenario index.")
-        cols = [str(s) for s in scenario]
-        unique_cols = list(dict.fromkeys(cols))
+        unique_scenarios, inverse = np.unique(scenario, return_inverse=True)
+        unique_cols = [str(s) for s in unique_scenarios]
         row = pl.scan_parquet(self.uri).select(unique_cols).head(1).collect().to_numpy()[0]
-        col_pos = {c: i for i, c in enumerate(unique_cols)}
-        result = row[[col_pos[c] for c in cols]]
+        result = row[inverse]
         if timestep is not None:
             return np.broadcast_to(result[np.newaxis, :], (len(timestep), len(scenario)))
         return result
@@ -233,12 +232,10 @@ class LazyTimeScenarioSeriesData(AbstractDataStructure):
             raise KeyError("Time scenario data requires a time index.")
         if scenario is None:
             raise KeyError("Time scenario data requires a scenario index.")
-        cols = [str(s) for s in scenario]
-        unique_cols = list(dict.fromkeys(cols))
+        unique_scenarios, inverse = np.unique(scenario, return_inverse=True)
+        unique_cols = [str(s) for s in unique_scenarios]
         df = pl.scan_parquet(self.uri).select(unique_cols).collect()
-        col_pos = {c: i for i, c in enumerate(unique_cols)}
-        data = df.to_numpy()[:, [col_pos[c] for c in cols]]
-        return data[np.asarray(timestep), :]
+        return df.to_numpy()[np.asarray(timestep)][:, inverse]
 
     def materialize(self, scenario_cols: Set[int]) -> "MaterializedTimeScenarioSeriesData":
         str_cols = [str(c) for c in sorted(scenario_cols)]
@@ -258,10 +255,18 @@ class MaterializedTimeScenarioSeriesData(AbstractDataStructure):
     col_pos maps each original data-series column index to its position
     in the in-memory data array, enabling the same deduplication /
     re-expansion logic as the lazy counterpart.
+    _lookup is a pre-built dense array for O(1) vectorized col_pos lookups.
     """
 
     data: np.ndarray  # shape (T, n_loaded_cols)
     col_pos: Dict[int, int]  # original col idx → position in data
+    _lookup: np.ndarray = field(init=False, repr=False, hash=False, compare=False)
+
+    def __post_init__(self) -> None:
+        lookup = np.full(max(self.col_pos) + 1, -1, dtype=np.intp)
+        for orig, pos in self.col_pos.items():
+            lookup[orig] = pos
+        object.__setattr__(self, "_lookup", lookup)
 
     def get_value(
         self,
@@ -272,11 +277,10 @@ class MaterializedTimeScenarioSeriesData(AbstractDataStructure):
             raise KeyError("Time scenario data requires a time index.")
         if scenario is None:
             raise KeyError("Time scenario data requires a scenario index.")
-        positions = [self.col_pos[s] for s in scenario]
-        unique_pos = list(dict.fromkeys(positions))
-        pos_map = {p: i for i, p in enumerate(unique_pos)}
-        result = self.data[np.ix_(np.asarray(timestep), np.asarray(unique_pos))]
-        return result[:, [pos_map[p] for p in positions]]
+        positions = self._lookup[scenario]
+        unique_pos, inverse = np.unique(positions, return_inverse=True)
+        result = self.data[np.ix_(np.asarray(timestep), unique_pos)]
+        return result[:, inverse]
 
     def check_requirement(self, time: bool, scenario: bool) -> bool:
         return time and scenario

--- a/src/gems/study/data.py
+++ b/src/gems/study/data.py
@@ -169,7 +169,7 @@ class LazyTimeSeriesData(AbstractDataStructure):
             return np.broadcast_to(result[:, np.newaxis], (len(timestep), len(scenario)))
         return result
 
-    def materialize(self, scenario_cols: Set[int]) -> "TimeSeriesData":
+    def materialize(self) -> "TimeSeriesData":
         arr = pl.scan_parquet(self.uri).select("0").collect().to_numpy().ravel()
         return TimeSeriesData(pd.Series(arr))
 
@@ -204,7 +204,7 @@ class LazyScenarioSeriesData(AbstractDataStructure):
             return np.broadcast_to(result[np.newaxis, :], (len(timestep), len(scenario)))
         return result
 
-    def materialize(self, scenario_cols: Set[int]) -> "ScenarioSeriesData":
+    def materialize(self) -> "ScenarioSeriesData":
         row = pl.scan_parquet(self.uri).collect().to_numpy()[0]
         return ScenarioSeriesData(row)
 
@@ -400,10 +400,9 @@ class DataBase:
         """
         new_db = DataBase(scenario_builder=self._scenario_builder)
         mc_arr = np.asarray(mc_scenario_ids, dtype=int)
-        lazy_types = (LazyTimeSeriesData, LazyScenarioSeriesData, LazyTimeScenarioSeriesData)
         for idx, raw_data in self._data.items():
             group = self._scenario_groups.get(idx)
-            if isinstance(raw_data, lazy_types):
+            if isinstance(raw_data, LazyTimeScenarioSeriesData):
                 if self._scenario_builder is not None and group is not None:
                     scenario_cols = set(
                         self._scenario_builder.resolve_vectorized(group, mc_arr).tolist()
@@ -411,6 +410,8 @@ class DataBase:
                 else:
                     scenario_cols = set(mc_arr.tolist())
                 materialized: AbstractDataStructure = raw_data.materialize(scenario_cols)
+            elif isinstance(raw_data, (LazyTimeSeriesData, LazyScenarioSeriesData)):
+                materialized = raw_data.materialize()
             else:
                 materialized = raw_data
             new_db.add_data(

--- a/src/gems/study/data.py
+++ b/src/gems/study/data.py
@@ -198,9 +198,10 @@ class LazyScenarioSeriesData(AbstractDataStructure):
         if scenario is None:
             raise KeyError("Scenario series data requires a scenario index.")
         cols = [str(s) for s in scenario]
-        result = (
-            pl.scan_parquet(self.uri).select(cols).head(1).collect().to_numpy()[0]
-        )
+        unique_cols = list(dict.fromkeys(cols))
+        row = pl.scan_parquet(self.uri).select(unique_cols).head(1).collect().to_numpy()[0]
+        col_pos = {c: i for i, c in enumerate(unique_cols)}
+        result = row[[col_pos[c] for c in cols]]
         if timestep is not None:
             return np.broadcast_to(
                 result[np.newaxis, :], (len(timestep), len(scenario))
@@ -233,7 +234,10 @@ class LazyTimeScenarioSeriesData(AbstractDataStructure):
         if scenario is None:
             raise KeyError("Time scenario data requires a scenario index.")
         cols = [str(s) for s in scenario]
-        data = pl.scan_parquet(self.uri).select(cols).collect().to_numpy()
+        unique_cols = list(dict.fromkeys(cols))
+        df = pl.scan_parquet(self.uri).select(unique_cols).collect()
+        col_pos = {c: i for i, c in enumerate(unique_cols)}
+        data = df.to_numpy()[:, [col_pos[c] for c in cols]]
         return data[np.asarray(timestep), :]
 
     def check_requirement(self, time: bool, scenario: bool) -> bool:

--- a/src/gems/study/data.py
+++ b/src/gems/study/data.py
@@ -12,7 +12,7 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Dict, List, Optional, Set, Union
 
 import numpy as np
 import pandas as pd
@@ -86,9 +86,7 @@ class TimeSeriesData(AbstractDataStructure):
             raise KeyError("Time series data requires a time index.")
         result: np.ndarray = np.asarray(self.time_series.values)[np.asarray(timestep)]
         if scenario is not None:
-            return np.broadcast_to(
-                result[:, np.newaxis], (len(timestep), len(scenario))
-            )
+            return np.broadcast_to(result[:, np.newaxis], (len(timestep), len(scenario)))
         return result
 
     def check_requirement(self, time: bool, scenario: bool) -> bool:
@@ -115,9 +113,7 @@ class ScenarioSeriesData(AbstractDataStructure):
             raise KeyError("Scenario series data requires a scenario index.")
         result = self.scenario_series[scenario]  # (S,)
         if timestep is not None:
-            return np.broadcast_to(
-                result[np.newaxis, :], (len(timestep), len(scenario))
-            )
+            return np.broadcast_to(result[np.newaxis, :], (len(timestep), len(scenario)))
         return result
 
     def check_requirement(self, time: bool, scenario: bool) -> bool:
@@ -170,10 +166,12 @@ class LazyTimeSeriesData(AbstractDataStructure):
         arr = pl.scan_parquet(self.uri).select("0").collect().to_numpy().ravel()
         result = arr[np.asarray(timestep)]
         if scenario is not None:
-            return np.broadcast_to(
-                result[:, np.newaxis], (len(timestep), len(scenario))
-            )
+            return np.broadcast_to(result[:, np.newaxis], (len(timestep), len(scenario)))
         return result
+
+    def materialize(self, scenario_cols: Set[int]) -> "TimeSeriesData":
+        arr = pl.scan_parquet(self.uri).select("0").collect().to_numpy().ravel()
+        return TimeSeriesData(pd.Series(arr))
 
     def check_requirement(self, time: bool, scenario: bool) -> bool:
         return time
@@ -203,10 +201,12 @@ class LazyScenarioSeriesData(AbstractDataStructure):
         col_pos = {c: i for i, c in enumerate(unique_cols)}
         result = row[[col_pos[c] for c in cols]]
         if timestep is not None:
-            return np.broadcast_to(
-                result[np.newaxis, :], (len(timestep), len(scenario))
-            )
+            return np.broadcast_to(result[np.newaxis, :], (len(timestep), len(scenario)))
         return result
+
+    def materialize(self, scenario_cols: Set[int]) -> "ScenarioSeriesData":
+        row = pl.scan_parquet(self.uri).collect().to_numpy()[0]
+        return ScenarioSeriesData(row)
 
     def check_requirement(self, time: bool, scenario: bool) -> bool:
         return scenario
@@ -240,13 +240,49 @@ class LazyTimeScenarioSeriesData(AbstractDataStructure):
         data = df.to_numpy()[:, [col_pos[c] for c in cols]]
         return data[np.asarray(timestep), :]
 
+    def materialize(self, scenario_cols: Set[int]) -> "MaterializedTimeScenarioSeriesData":
+        str_cols = [str(c) for c in sorted(scenario_cols)]
+        df = pl.scan_parquet(self.uri).select(str_cols).collect()
+        col_pos = {int(c): i for i, c in enumerate(str_cols)}
+        return MaterializedTimeScenarioSeriesData(data=df.to_numpy(), col_pos=col_pos)
+
     def check_requirement(self, time: bool, scenario: bool) -> bool:
         return time and scenario
 
 
-def load_ts_from_file(
-    timeseries_name: Optional[str], path_to_file: Optional[Path]
-) -> pd.DataFrame:
+@dataclass(frozen=True)
+class MaterializedTimeScenarioSeriesData(AbstractDataStructure):
+    """Pre-loaded subset of a time×scenario parquet file.
+
+    Holds only the data-series columns required by the current worker.
+    col_pos maps each original data-series column index to its position
+    in the in-memory data array, enabling the same deduplication /
+    re-expansion logic as the lazy counterpart.
+    """
+
+    data: np.ndarray  # shape (T, n_loaded_cols)
+    col_pos: Dict[int, int]  # original col idx → position in data
+
+    def get_value(
+        self,
+        timestep: Optional[List[int]],
+        scenario: Optional[np.ndarray],
+    ) -> np.ndarray:
+        if timestep is None:
+            raise KeyError("Time scenario data requires a time index.")
+        if scenario is None:
+            raise KeyError("Time scenario data requires a scenario index.")
+        positions = [self.col_pos[s] for s in scenario]
+        unique_pos = list(dict.fromkeys(positions))
+        pos_map = {p: i for i, p in enumerate(unique_pos)}
+        result = self.data[np.ix_(np.asarray(timestep), np.asarray(unique_pos))]
+        return result[:, [pos_map[p] for p in positions]]
+
+    def check_requirement(self, time: bool, scenario: bool) -> bool:
+        return time and scenario
+
+
+def load_ts_from_file(timeseries_name: Optional[str], path_to_file: Optional[Path]) -> pd.DataFrame:
     if path_to_file is None or timeseries_name is None:
         raise FileNotFoundError(f"File '{timeseries_name}' does not exist")
 
@@ -265,9 +301,7 @@ def load_ts_from_file(
             break
 
     if last_exc is not None:
-        raise Exception(
-            f"An error has arrived when processing '{candidate}': {last_exc}"
-        )
+        raise Exception(f"An error has arrived when processing '{candidate}': {last_exc}")
 
     raise FileNotFoundError(
         f"File '{timeseries_name}.txt' or '{timeseries_name}.tsv' does not exist"
@@ -356,6 +390,33 @@ class DataBase:
             )
 
         return raw_data.get_value(timesteps, cols)
+
+    def materialize(self, mc_scenario_ids: List[int]) -> "DataBase":
+        """Return a new DataBase with every lazy entry replaced by pre-loaded in-memory data.
+
+        Only the data-series columns that the given MC scenario IDs map to are
+        loaded from each parquet file (via ScenarioBuilder when present).
+        Eager entries are carried over as-is.  The original DataBase is never mutated.
+        """
+        new_db = DataBase(scenario_builder=self._scenario_builder)
+        mc_arr = np.asarray(mc_scenario_ids, dtype=int)
+        lazy_types = (LazyTimeSeriesData, LazyScenarioSeriesData, LazyTimeScenarioSeriesData)
+        for idx, raw_data in self._data.items():
+            group = self._scenario_groups.get(idx)
+            if isinstance(raw_data, lazy_types):
+                if self._scenario_builder is not None and group is not None:
+                    scenario_cols = set(
+                        self._scenario_builder.resolve_vectorized(group, mc_arr).tolist()
+                    )
+                else:
+                    scenario_cols = set(mc_arr.tolist())
+                materialized: AbstractDataStructure = raw_data.materialize(scenario_cols)
+            else:
+                materialized = raw_data
+            new_db.add_data(
+                idx.component_id, idx.parameter_name, materialized, scenario_group=group
+            )
+        return new_db
 
     def get_value(
         self, index: ComponentParameterIndex, timestep: int, scenario: int

--- a/src/gems/study/data.py
+++ b/src/gems/study/data.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
 import numpy as np
 import pandas as pd
+import polars as pl
 
 if TYPE_CHECKING:
     from gems.study.scenario_builder import ScenarioBuilder
@@ -145,6 +146,97 @@ class TimeScenarioSeriesData(AbstractDataStructure):
     def check_requirement(self, time: bool, scenario: bool) -> bool:
         if not isinstance(self, TimeScenarioSeriesData):
             raise ValueError("Invalid data type for TimeScenarioSeriesData")
+        return time and scenario
+
+
+@dataclass(frozen=True)
+class LazyTimeSeriesData(AbstractDataStructure):
+    """Polars-backed time series: defers parquet I/O to get_value call time.
+
+    Parquet layout: one column named ``"0"``, T rows (one per timestep).
+    Column pruning is not applicable here (single column), but row indexing
+    is still deferred until the optimizer requests a specific time block.
+    """
+
+    uri: str
+
+    def get_value(
+        self,
+        timestep: Optional[List[int]],
+        scenario: Optional[np.ndarray],
+    ) -> np.ndarray:
+        if timestep is None:
+            raise KeyError("Time series data requires a time index.")
+        arr = pl.scan_parquet(self.uri).select("0").collect().to_numpy().ravel()
+        result = arr[np.asarray(timestep)]
+        if scenario is not None:
+            return np.broadcast_to(
+                result[:, np.newaxis], (len(timestep), len(scenario))
+            )
+        return result
+
+    def check_requirement(self, time: bool, scenario: bool) -> bool:
+        return time
+
+
+@dataclass(frozen=True)
+class LazyScenarioSeriesData(AbstractDataStructure):
+    """Polars-backed scenario series: defers parquet I/O to get_value call time.
+
+    Parquet layout: S columns named ``"0"`` … ``"S-1"``, T rows all identical
+    (Parquet RLE compresses this to near-zero overhead).  Only the requested
+    scenario columns are read from disk.
+    """
+
+    uri: str
+
+    def get_value(
+        self,
+        timestep: Optional[List[int]],
+        scenario: Optional[np.ndarray],
+    ) -> np.ndarray:
+        if scenario is None:
+            raise KeyError("Scenario series data requires a scenario index.")
+        cols = [str(s) for s in scenario]
+        result = (
+            pl.scan_parquet(self.uri).select(cols).head(1).collect().to_numpy()[0]
+        )
+        if timestep is not None:
+            return np.broadcast_to(
+                result[np.newaxis, :], (len(timestep), len(scenario))
+            )
+        return result
+
+    def check_requirement(self, time: bool, scenario: bool) -> bool:
+        return scenario
+
+
+@dataclass(frozen=True)
+class LazyTimeScenarioSeriesData(AbstractDataStructure):
+    """Polars-backed time×scenario series: defers parquet I/O to get_value call time.
+
+    Parquet layout: S columns named ``"0"`` … ``"S-1"``, T rows (one per
+    timestep).  Polars column pruning reads only the requested scenario columns;
+    row indexing is applied after collection.  This is the primary beneficiary
+    of parquet lazy loading — only B/S columns are read per worker batch.
+    """
+
+    uri: str
+
+    def get_value(
+        self,
+        timestep: Optional[List[int]],
+        scenario: Optional[np.ndarray],
+    ) -> np.ndarray:
+        if timestep is None:
+            raise KeyError("Time scenario data requires a time index.")
+        if scenario is None:
+            raise KeyError("Time scenario data requires a scenario index.")
+        cols = [str(s) for s in scenario]
+        data = pl.scan_parquet(self.uri).select(cols).collect().to_numpy()
+        return data[np.asarray(timestep), :]
+
+    def check_requirement(self, time: bool, scenario: bool) -> bool:
         return time and scenario
 
 

--- a/src/gems/study/resolve_components.py
+++ b/src/gems/study/resolve_components.py
@@ -26,6 +26,9 @@ from gems.study import (
 )
 from gems.study.data import (
     AbstractDataStructure,
+    LazyScenarioSeriesData,
+    LazyTimeScenarioSeriesData,
+    LazyTimeSeriesData,
     ScenarioSeriesData,
     TimeScenarioSeriesData,
     TimeSeriesData,
@@ -138,6 +141,20 @@ def _build_data(
     timeseries_dir: Optional[Path],
 ) -> AbstractDataStructure:
     if isinstance(param_value, str):
+        if timeseries_dir is not None:
+            parquet_path = timeseries_dir / f"{param_value}.parquet"
+            if parquet_path.exists():
+                uri = str(parquet_path)
+                if time_dependent and scenario_dependent:
+                    return LazyTimeScenarioSeriesData(uri)
+                elif time_dependent:
+                    return LazyTimeSeriesData(uri)
+                elif scenario_dependent:
+                    return LazyScenarioSeriesData(uri)
+                else:
+                    raise ValueError(
+                        f"A float value is expected for constant data, got {param_value}"
+                    )
         ts_data = load_ts_from_file(param_value, timeseries_dir)
         if time_dependent and scenario_dependent:
             return TimeScenarioSeriesData(ts_data)

--- a/src/gems/study/resolve_components.py
+++ b/src/gems/study/resolve_components.py
@@ -45,9 +45,7 @@ def resolve_system(input_system: SystemSchema, libraries: dict[str, Library]) ->
     Resolves:
     - components to be used for study
     - connections between components"""
-    components_list = [
-        _resolve_component(libraries, m) for m in input_system.components
-    ]
+    components_list = [_resolve_component(libraries, m) for m in input_system.components]
 
     s = System("study")
     for component in components_list:
@@ -61,9 +59,7 @@ def resolve_system(input_system: SystemSchema, libraries: dict[str, Library]) ->
     return s
 
 
-def _resolve_component(
-    libraries: dict[str, Library], component: ComponentSchema
-) -> Component:
+def _resolve_component(libraries: dict[str, Library], component: ComponentSchema) -> Component:
     lib_id, model_id = component.model.split(".")
     model = libraries[lib_id].models[f"{lib_id}.{model_id}"]
 
@@ -81,14 +77,10 @@ def _resolve_port_refs(
     component_1 = _get_component_by_id(all_components, connection.component1)
     component_2 = _get_component_by_id(all_components, connection.component2)
     assert component_1 is not None and component_2 is not None
-    return PortRef(component_1, connection.port1), PortRef(
-        component_2, connection.port2
-    )
+    return PortRef(component_1, connection.port1), PortRef(component_2, connection.port2)
 
 
-def _get_component_by_id(
-    all_components: List[Component], component_id: str
-) -> Optional[Component]:
+def _get_component_by_id(all_components: List[Component], component_id: str) -> Optional[Component]:
     components_dict = {component.id: component for component in all_components}
     return components_dict.get(component_id)
 
@@ -163,9 +155,7 @@ def _build_data(
         elif scenario_dependent:
             return ScenarioSeriesData(dataframe_to_scenario_series(ts_data))
         else:
-            raise ValueError(
-                f"A float value is expected for constant data, got {param_value}"
-            )
+            raise ValueError(f"A float value is expected for constant data, got {param_value}")
     else:
         if time_dependent or scenario_dependent:
             raise ValueError(

--- a/src/gems/study/study.py
+++ b/src/gems/study/study.py
@@ -38,6 +38,13 @@ class Study:
     database: DataBase
     scenario_builder: ScenarioBuilder = field(default_factory=ScenarioBuilder)
 
+    def __post_init__(self) -> None:
+        # Pre-populate both cached properties at construction time so that
+        # concurrent worker threads only ever perform reads, never a racy
+        # first-write through cached_property.__set_name__.
+        _ = self.model_components
+        _ = self.models
+
     @cached_property
     def model_components(self) -> Dict[str, List[Component]]:
         """Components grouped by their model.id."""
@@ -49,9 +56,7 @@ class Study:
     @cached_property
     def models(self) -> Dict[str, Model]:
         """All unique models in the system, keyed by model.id."""
-        return {
-            mk: components[0].model for mk, components in self.model_components.items()
-        }
+        return {mk: components[0].model for mk, components in self.model_components.items()}
 
     def check_consistency(self) -> None:
         """Validate that the database supplies data for every parameter of every

--- a/tests/e2e/functional/test_parquet_complex_study.py
+++ b/tests/e2e/functional/test_parquet_complex_study.py
@@ -1,0 +1,164 @@
+# Copyright (c) 2024, RTE (https://www.rte-france.com)
+#
+# See AUTHORS.txt
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# SPDX-License-Identifier: MPL-2.0
+#
+# This file is part of the Antares project.
+
+"""
+E2E comparison test for the 7_4 study:
+  12 components, 11 connections, 76 database entries, 168 timesteps, 1 scenario.
+
+Two time×scenario data series are loaded from TSV files:
+  - load_ts_base028  →  component load_base_zone,  parameter load
+  - wind_ts_base028  →  component wind_base_zone,  parameter generation
+
+Both tests run the full study twice — once with the original TSV files and
+once with Polars-written Parquet equivalents — and assert that every row of
+the simulation table is numerically identical.
+
+test_7_4_parquet_coexisting_with_tsv_same_result
+    TSV and parquet files coexist in the series directory.
+    Parquet takes precedence; TSV is the silent fallback.
+
+test_7_4_parquet_only_same_result_as_tsv
+    TSV files are removed after conversion; only parquet remains.
+    Verifies that the lazy path works standalone, without a txt/tsv backup.
+"""
+
+import shutil
+from pathlib import Path
+
+import polars as pl
+from polars.testing import assert_frame_equal
+import pytest
+
+from gems.study.data import LazyTimeScenarioSeriesData
+from gems.study.folder import load_study
+from gems.study.runner import run_study
+
+_STUDY_SRC = Path(__file__).parent / "studies" / "7_4"
+
+# Pairs (component_id, parameter_id) whose data comes from a TSV file.
+_TS_PARAMS = [
+    ("load_base_zone", "load"),
+    ("wind_base_zone", "generation"),
+]
+
+
+def _convert_tsv_to_parquet(series_dir: Path) -> None:
+    """Convert every .tsv file to a .parquet with 0-based string column names.
+
+    Tab-separated files are read by Polars, columns renamed "0", "1", …,
+    then written as Parquet.  The original TSV files are left untouched so
+    both formats can coexist if desired.
+    """
+    for tsv in series_dir.glob("*.tsv"):
+        df = pl.read_csv(tsv, has_header=False, separator="\t")
+        df = df.rename({old: str(i) for i, old in enumerate(df.columns)})
+        df.write_parquet(tsv.with_suffix(".parquet"))
+
+
+def _run_and_get_csv(study_dir: Path) -> Path:
+    run_study(study_dir)
+    output_files = list((study_dir / "output").glob("**/simulation_table_*.csv"))
+    assert len(output_files) == 1, f"Expected 1 output file, got {len(output_files)}"
+    return output_files[0]
+
+
+def _compare_simulation_tables(ref_csv: Path, other_csv: Path) -> None:
+    """Assert that two simulation-table CSV files are numerically identical.
+
+    Rows are sorted by (component, output, absolute-time-index, scenario-index)
+    so that non-deterministic output ordering does not cause false failures.
+    Null-valued index columns (objective-value rows) sort consistently because
+    Polars places nulls last in ascending sort by default.
+    """
+    key_cols = [
+        "component",
+        "output",
+        "absolute-time-index",
+        "scenario-index",
+    ]
+    ref = pl.read_csv(ref_csv).sort(key_cols, nulls_last=True)
+    other = pl.read_csv(other_csv).sort(key_cols, nulls_last=True)
+    assert_frame_equal(ref, other, check_exact=False, abs_tol=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# Test 1: parquet + tsv coexist — parquet takes precedence
+# ---------------------------------------------------------------------------
+
+
+def test_7_4_parquet_coexisting_with_tsv_same_result(tmp_path: Path) -> None:
+    """TSV and parquet coexist; parquet wins and produces identical results.
+
+    Reference run uses the original TSV files (eager TimeScenarioSeriesData).
+    Parquet run adds .parquet files alongside each .tsv; the lazy path is
+    selected and the original TSV files remain as silent fallbacks.
+    Both simulation tables must be numerically identical.
+    """
+    # --- Reference run (original TSV) ---
+    ref_dir = tmp_path / "ref"
+    shutil.copytree(_STUDY_SRC, ref_dir)
+    ref_csv = _run_and_get_csv(ref_dir)
+
+    # --- Parquet run (parquet + tsv coexist) ---
+    pq_dir = tmp_path / "parquet"
+    shutil.copytree(_STUDY_SRC, pq_dir)
+    _convert_tsv_to_parquet(pq_dir / "input" / "data-series")
+    pq_csv = _run_and_get_csv(pq_dir)
+
+    # Verify lazy structures are used (parquet took precedence over tsv)
+    study = load_study(pq_dir)
+    for comp_id, param_id in _TS_PARAMS:
+        ds = study.database.get_data(comp_id, param_id)
+        assert isinstance(ds, LazyTimeScenarioSeriesData), (
+            f"{comp_id}.{param_id}: expected LazyTimeScenarioSeriesData, got {type(ds).__name__}"
+        )
+
+    _compare_simulation_tables(ref_csv, pq_csv)
+
+
+# ---------------------------------------------------------------------------
+# Test 2: parquet only — no tsv fallback
+# ---------------------------------------------------------------------------
+
+
+def test_7_4_parquet_only_same_result_as_tsv(tmp_path: Path) -> None:
+    """Parquet-only series directory: lazy path works without any TSV fallback.
+
+    Reference run uses the original TSV files.
+    Parquet run converts TSV→parquet then removes the TSV files entirely,
+    so the only available format is parquet.
+    Both simulation tables must be numerically identical.
+    """
+    # --- Reference run (original TSV) ---
+    ref_dir = tmp_path / "ref"
+    shutil.copytree(_STUDY_SRC, ref_dir)
+    ref_csv = _run_and_get_csv(ref_dir)
+
+    # --- Parquet-only run ---
+    pq_dir = tmp_path / "parquet_only"
+    shutil.copytree(_STUDY_SRC, pq_dir)
+    series_dir = pq_dir / "input" / "data-series"
+    _convert_tsv_to_parquet(series_dir)
+    for tsv in series_dir.glob("*.tsv"):
+        tsv.unlink()
+
+    pq_csv = _run_and_get_csv(pq_dir)
+
+    # Verify lazy structures are used (no tsv to fall back on)
+    study = load_study(pq_dir)
+    for comp_id, param_id in _TS_PARAMS:
+        ds = study.database.get_data(comp_id, param_id)
+        assert isinstance(ds, LazyTimeScenarioSeriesData), (
+            f"{comp_id}.{param_id}: expected LazyTimeScenarioSeriesData, got {type(ds).__name__}"
+        )
+
+    _compare_simulation_tables(ref_csv, pq_csv)

--- a/tests/e2e/functional/test_parquet_complex_study.py
+++ b/tests/e2e/functional/test_parquet_complex_study.py
@@ -35,8 +35,8 @@ import shutil
 from pathlib import Path
 
 import polars as pl
-from polars.testing import assert_frame_equal
 import pytest
+from polars.testing import assert_frame_equal
 
 from gems.study.data import LazyTimeScenarioSeriesData
 from gems.study.folder import load_study
@@ -118,9 +118,9 @@ def test_7_4_parquet_coexisting_with_tsv_same_result(tmp_path: Path) -> None:
     study = load_study(pq_dir)
     for comp_id, param_id in _TS_PARAMS:
         ds = study.database.get_data(comp_id, param_id)
-        assert isinstance(ds, LazyTimeScenarioSeriesData), (
-            f"{comp_id}.{param_id}: expected LazyTimeScenarioSeriesData, got {type(ds).__name__}"
-        )
+        assert isinstance(
+            ds, LazyTimeScenarioSeriesData
+        ), f"{comp_id}.{param_id}: expected LazyTimeScenarioSeriesData, got {type(ds).__name__}"
 
     _compare_simulation_tables(ref_csv, pq_csv)
 
@@ -157,8 +157,8 @@ def test_7_4_parquet_only_same_result_as_tsv(tmp_path: Path) -> None:
     study = load_study(pq_dir)
     for comp_id, param_id in _TS_PARAMS:
         ds = study.database.get_data(comp_id, param_id)
-        assert isinstance(ds, LazyTimeScenarioSeriesData), (
-            f"{comp_id}.{param_id}: expected LazyTimeScenarioSeriesData, got {type(ds).__name__}"
-        )
+        assert isinstance(
+            ds, LazyTimeScenarioSeriesData
+        ), f"{comp_id}.{param_id}: expected LazyTimeScenarioSeriesData, got {type(ds).__name__}"
 
     _compare_simulation_tables(ref_csv, pq_csv)

--- a/tests/e2e/functional/test_parquet_dataseries.py
+++ b/tests/e2e/functional/test_parquet_dataseries.py
@@ -1,0 +1,194 @@
+# Copyright (c) 2024, RTE (https://www.rte-france.com)
+#
+# See AUTHORS.txt
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# SPDX-License-Identifier: MPL-2.0
+#
+# This file is part of the Antares project.
+
+"""
+E2E tests verifying that Polars-backed lazy parquet data structures produce
+the same optimization results as the existing txt-based eager structures.
+
+Three lazy data types are exercised:
+  - LazyTimeSeriesData         (time-only, mirrors test_basic_balance_time_only_series)
+  - LazyScenarioSeriesData     (scenario-only, mirrors test_basic_balance_scenario_only_series)
+  - LazyTimeScenarioSeriesData (time × scenario with ScenarioBuilder,
+                                mirrors test_system_with_scenarization)
+
+One additional test verifies that a parquet file takes precedence over a
+co-located .txt file (backward-compatibility guarantee).
+
+Parquet files are written to tmp_path so no fixture files are polluted.
+"""
+
+import shutil
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+from gems.model.parsing import parse_yaml_library
+from gems.model.resolve_library import resolve_library
+from gems.simulation import TimeBlock, build_problem
+from gems.study.data import (
+    LazyScenarioSeriesData,
+    LazyTimeScenarioSeriesData,
+    LazyTimeSeriesData,
+)
+from gems.study.parsing import parse_yaml_components
+from gems.study.resolve_components import build_data_base, consistency_check, resolve_system
+from gems.study.scenario_builder import ScenarioBuilder
+from gems.study.study import Study
+
+_SYSTEMS_DIR = Path(__file__).parent / "systems"
+_LIBS_DIR = Path(__file__).parent / "libs"
+_SERIES_DIR = Path(__file__).parent / "series"
+
+
+def _build_study(
+    system_file: str,
+    series_path: Path,
+    scenario_builder: ScenarioBuilder | None = None,
+) -> tuple[Study, object]:
+    """Parse lib + system YAML and build Study from a given series directory."""
+    with (_LIBS_DIR / "lib_unittest.yml").open() as f:
+        lib_dict = resolve_library([parse_yaml_library(f)])
+    with (_SYSTEMS_DIR / system_file).open() as f:
+        input_system = parse_yaml_components(f)
+    system = resolve_system(input_system, lib_dict)
+    consistency_check(system, lib_dict["basic"].models)
+    database = build_data_base(input_system, series_path, scenario_builder)
+    return Study(system, database), database
+
+
+# ---------------------------------------------------------------------------
+# Time-only series
+# ---------------------------------------------------------------------------
+
+
+def test_parquet_time_series_same_result_as_txt(tmp_path: Path) -> None:
+    """LazyTimeSeriesData gives the same objective as TimeSeriesData from .txt.
+
+    Mirrors test_basic_balance_time_only_series:
+      demand = 50 per timestep, generator cost = 100, horizon = 2
+      → objective = 100 × 50 × 2 = 10 000.
+
+    Parquet layout: single column "0", two rows [50.0, 50.0].
+    """
+    pl.DataFrame({"0": [50.0, 50.0]}).write_parquet(
+        tmp_path / "loads-time-only.parquet"
+    )
+
+    study, database = _build_study("study_time_only_series.yml", tmp_path)
+
+    assert isinstance(
+        database.get_data("D", "demand"), LazyTimeSeriesData
+    ), "Expected LazyTimeSeriesData; txt fallback was used instead"
+
+    problem = build_problem(study, TimeBlock(1, [0, 1]), [0])
+    problem.solve(solver_name="highs")
+    assert problem.termination_condition == "optimal"
+    assert problem.objective_value == pytest.approx(10_000)
+
+
+# ---------------------------------------------------------------------------
+# Scenario-only series
+# ---------------------------------------------------------------------------
+
+
+def test_parquet_scenario_series_same_result_as_txt(tmp_path: Path) -> None:
+    """LazyScenarioSeriesData gives the same objective as ScenarioSeriesData.
+
+    Mirrors test_basic_balance_scenario_only_series:
+      two scenarios with demand 50 (col 0) and 100 (col 1), cost = 100
+      → objective = 0.5 × 5 000 + 0.5 × 10 000 = 7 500.
+
+    Parquet layout: columns "0" and "1", one row each.
+    """
+    pl.DataFrame({"0": [50.0], "1": [100.0]}).write_parquet(
+        tmp_path / "loads-scenario-only.parquet"
+    )
+
+    study, database = _build_study("study_scenario_only_series.yml", tmp_path)
+
+    assert isinstance(
+        database.get_data("D", "demand"), LazyScenarioSeriesData
+    ), "Expected LazyScenarioSeriesData; txt fallback was used instead"
+
+    problem = build_problem(study, TimeBlock(1, [0]), [0, 1])
+    problem.solve(solver_name="highs")
+    assert problem.termination_condition == "optimal"
+    assert problem.objective_value == pytest.approx(0.5 * 5_000 + 0.5 * 10_000)
+
+
+# ---------------------------------------------------------------------------
+# Time × scenario series — with ScenarioBuilder
+# ---------------------------------------------------------------------------
+
+
+def test_parquet_time_scenario_series_same_result_as_txt(tmp_path: Path) -> None:
+    """LazyTimeScenarioSeriesData gives the same objective with ScenarioBuilder.
+
+    Mirrors test_system_with_scenarization (test_scenario_builder.py):
+      loads.txt has T=2 rows and S=2 data-series columns:
+        col 0 → demand 50, col 1 → demand 100.
+      The ScenarioBuilder maps 3 MC scenarios to columns [0, 1, 0], so:
+        MC 0 → 50, MC 1 → 100, MC 2 → 50
+      Expected objective = (10 000 + 20 000 + 10 000) / 3 = 40 000 / 3.
+
+    Parquet layout: columns "0" and "1", two rows (one per timestep).
+    """
+    pl.DataFrame({"0": [50.0, 50.0], "1": [100.0, 100.0]}).write_parquet(
+        tmp_path / "loads.parquet"
+    )
+    shutil.copy(_SERIES_DIR / "modeler-scenariobuilder.dat", tmp_path)
+    scenario_builder = ScenarioBuilder.load(tmp_path / "modeler-scenariobuilder.dat")
+
+    study, database = _build_study(
+        "with_scenarization.yml", tmp_path, scenario_builder
+    )
+
+    assert isinstance(
+        database.get_data("D", "demand"), LazyTimeScenarioSeriesData
+    ), "Expected LazyTimeScenarioSeriesData; txt fallback was used instead"
+
+    problem = build_problem(study, TimeBlock(1, [0, 1]), [0, 1, 2])
+    problem.solve(solver_name="highs")
+    assert problem.termination_condition == "optimal"
+    assert problem.objective_value == pytest.approx(40_000 / 3, abs=0.001)
+
+
+# ---------------------------------------------------------------------------
+# Parquet takes precedence over .txt when both are present
+# ---------------------------------------------------------------------------
+
+
+def test_parquet_takes_precedence_when_both_formats_present(tmp_path: Path) -> None:
+    """When both .parquet and .txt exist in the series dir, parquet is selected.
+
+    Copies the existing loads-time-only.txt alongside a parquet file with the
+    same content, then verifies that the lazy structure is used and the result
+    is unchanged.
+    """
+    shutil.copy(
+        _SERIES_DIR / "loads-time-only.txt", tmp_path / "loads-time-only.txt"
+    )
+    pl.DataFrame({"0": [50.0, 50.0]}).write_parquet(
+        tmp_path / "loads-time-only.parquet"
+    )
+
+    study, database = _build_study("study_time_only_series.yml", tmp_path)
+
+    assert isinstance(
+        database.get_data("D", "demand"), LazyTimeSeriesData
+    ), "Parquet file should take precedence over the co-located .txt file"
+
+    problem = build_problem(study, TimeBlock(1, [0, 1]), [0])
+    problem.solve(solver_name="highs")
+    assert problem.termination_condition == "optimal"
+    assert problem.objective_value == pytest.approx(10_000)

--- a/tests/e2e/functional/test_parquet_dataseries.py
+++ b/tests/e2e/functional/test_parquet_dataseries.py
@@ -34,14 +34,21 @@ import pytest
 
 from gems.model.parsing import parse_yaml_library
 from gems.model.resolve_library import resolve_library
+from gems.optim_config.parsing import OptimConfig
+from gems.session.session import SimulationSession
 from gems.simulation import TimeBlock, build_problem
 from gems.study.data import (
     LazyScenarioSeriesData,
     LazyTimeScenarioSeriesData,
     LazyTimeSeriesData,
+    MaterializedTimeScenarioSeriesData,
 )
 from gems.study.parsing import parse_yaml_components
-from gems.study.resolve_components import build_data_base, consistency_check, resolve_system
+from gems.study.resolve_components import (
+    build_data_base,
+    consistency_check,
+    resolve_system,
+)
 from gems.study.scenario_builder import ScenarioBuilder
 from gems.study.study import Study
 
@@ -80,9 +87,7 @@ def test_parquet_time_series_same_result_as_txt(tmp_path: Path) -> None:
 
     Parquet layout: single column "0", two rows [50.0, 50.0].
     """
-    pl.DataFrame({"0": [50.0, 50.0]}).write_parquet(
-        tmp_path / "loads-time-only.parquet"
-    )
+    pl.DataFrame({"0": [50.0, 50.0]}).write_parquet(tmp_path / "loads-time-only.parquet")
 
     study, database = _build_study("study_time_only_series.yml", tmp_path)
 
@@ -143,15 +148,11 @@ def test_parquet_time_scenario_series_same_result_as_txt(tmp_path: Path) -> None
 
     Parquet layout: columns "0" and "1", two rows (one per timestep).
     """
-    pl.DataFrame({"0": [50.0, 50.0], "1": [100.0, 100.0]}).write_parquet(
-        tmp_path / "loads.parquet"
-    )
+    pl.DataFrame({"0": [50.0, 50.0], "1": [100.0, 100.0]}).write_parquet(tmp_path / "loads.parquet")
     shutil.copy(_SERIES_DIR / "modeler-scenariobuilder.dat", tmp_path)
     scenario_builder = ScenarioBuilder.load(tmp_path / "modeler-scenariobuilder.dat")
 
-    study, database = _build_study(
-        "with_scenarization.yml", tmp_path, scenario_builder
-    )
+    study, database = _build_study("with_scenarization.yml", tmp_path, scenario_builder)
 
     assert isinstance(
         database.get_data("D", "demand"), LazyTimeScenarioSeriesData
@@ -175,12 +176,8 @@ def test_parquet_takes_precedence_when_both_formats_present(tmp_path: Path) -> N
     same content, then verifies that the lazy structure is used and the result
     is unchanged.
     """
-    shutil.copy(
-        _SERIES_DIR / "loads-time-only.txt", tmp_path / "loads-time-only.txt"
-    )
-    pl.DataFrame({"0": [50.0, 50.0]}).write_parquet(
-        tmp_path / "loads-time-only.parquet"
-    )
+    shutil.copy(_SERIES_DIR / "loads-time-only.txt", tmp_path / "loads-time-only.txt")
+    pl.DataFrame({"0": [50.0, 50.0]}).write_parquet(tmp_path / "loads-time-only.parquet")
 
     study, database = _build_study("study_time_only_series.yml", tmp_path)
 
@@ -192,3 +189,45 @@ def test_parquet_takes_precedence_when_both_formats_present(tmp_path: Path) -> N
     problem.solve(solver_name="highs")
     assert problem.termination_condition == "optimal"
     assert problem.objective_value == pytest.approx(10_000)
+
+
+# ---------------------------------------------------------------------------
+# materialize_per_worker
+# ---------------------------------------------------------------------------
+
+
+def test_materialize_per_worker_same_result_as_lazy(tmp_path: Path) -> None:
+    """materialize_per_worker=True produces the same objective as the lazy path.
+
+    Uses sequential-subproblems with block-length=1 over a 2-timestep horizon
+    so that materialize() is called once per scenario worker.
+    Verifies that the working database entry becomes MaterializedTimeScenarioSeriesData
+    and that the resulting objective is numerically identical to the lazy run.
+    """
+    pl.DataFrame({"0": [50.0, 50.0], "1": [100.0, 100.0]}).write_parquet(tmp_path / "loads.parquet")
+    shutil.copy(_SERIES_DIR / "modeler-scenariobuilder.dat", tmp_path)
+    scenario_builder = ScenarioBuilder.load(tmp_path / "modeler-scenariobuilder.dat")
+
+    study, database = _build_study("with_scenarization.yml", tmp_path, scenario_builder)
+    assert isinstance(database.get_data("D", "demand"), LazyTimeScenarioSeriesData)
+
+    optim_config = OptimConfig.model_validate(
+        {
+            "time-scope": {"first-time-step": 0, "last-time-step": 1},
+            "scenario-scope": {"nb-scenarios": 3},
+            "resolution": {"mode": "sequential-subproblems", "block-length": 1},
+        }
+    )
+
+    lazy_table = SimulationSession(study=study, optim_config=optim_config).run()
+    mat_table = SimulationSession(
+        study=study, optim_config=optim_config, materialize_per_worker=True
+    ).run()
+
+    # Verify materialization produces MaterializedTimeScenarioSeriesData
+    mat_db = study.database.materialize([0])
+    assert isinstance(mat_db.get_data("D", "demand"), MaterializedTimeScenarioSeriesData)
+
+    obj_rows_lazy = lazy_table.data.loc[lazy_table.data["output"] == "objective-value", "value"]
+    obj_rows_mat = mat_table.data.loc[mat_table.data["output"] == "objective-value", "value"]
+    assert obj_rows_lazy.sum() == pytest.approx(obj_rows_mat.sum(), rel=1e-6)

--- a/tests/e2e/functional/test_parquet_dataseries.py
+++ b/tests/e2e/functional/test_parquet_dataseries.py
@@ -35,7 +35,7 @@ import pytest
 from gems.model.parsing import parse_yaml_library
 from gems.model.resolve_library import resolve_library
 from gems.optim_config.parsing import OptimConfig
-from gems.session.session import SimulationSession
+from gems.session.session import MaterializationStrategy, SimulationSession
 from gems.simulation import TimeBlock, build_problem
 from gems.study.data import (
     LazyScenarioSeriesData,
@@ -196,22 +196,18 @@ def test_parquet_takes_precedence_when_both_formats_present(tmp_path: Path) -> N
 # ---------------------------------------------------------------------------
 
 
-def test_materialize_per_worker_same_result_as_lazy(tmp_path: Path) -> None:
-    """materialize_per_worker=True produces the same objective as the lazy path.
-
-    Uses sequential-subproblems with block-length=1 over a 2-timestep horizon
-    so that materialize() is called once per scenario worker.
-    Verifies that the working database entry becomes MaterializedTimeScenarioSeriesData
-    and that the resulting objective is numerically identical to the lazy run.
-    """
+def _make_scenarized_study(tmp_path: Path):
+    """Shared setup: 2-column parquet + ScenarioBuilder mapping 3 MC scenarios to 2 columns."""
     pl.DataFrame({"0": [50.0, 50.0], "1": [100.0, 100.0]}).write_parquet(tmp_path / "loads.parquet")
     shutil.copy(_SERIES_DIR / "modeler-scenariobuilder.dat", tmp_path)
     scenario_builder = ScenarioBuilder.load(tmp_path / "modeler-scenariobuilder.dat")
-
     study, database = _build_study("with_scenarization.yml", tmp_path, scenario_builder)
     assert isinstance(database.get_data("D", "demand"), LazyTimeScenarioSeriesData)
+    return study
 
-    optim_config = OptimConfig.model_validate(
+
+def _sequential_config() -> OptimConfig:
+    return OptimConfig.model_validate(
         {
             "time-scope": {"first-time-step": 0, "last-time-step": 1},
             "scenario-scope": {"nb-scenarios": 3},
@@ -219,15 +215,48 @@ def test_materialize_per_worker_same_result_as_lazy(tmp_path: Path) -> None:
         }
     )
 
+
+def test_materialize_per_worker_same_result_as_lazy(tmp_path: Path) -> None:
+    """MaterializationStrategy.PER_WORKER produces the same objective as NONE (lazy).
+
+    Uses sequential-subproblems with block-length=1 over a 2-timestep horizon
+    so that materialize() is called once per scenario.
+    Verifies that the database entry becomes MaterializedTimeScenarioSeriesData
+    and that the resulting objective is numerically identical to the lazy run.
+    """
+    study = _make_scenarized_study(tmp_path)
+    optim_config = _sequential_config()
+
     lazy_table = SimulationSession(study=study, optim_config=optim_config).run()
     mat_table = SimulationSession(
-        study=study, optim_config=optim_config, materialize_per_worker=True
+        study=study, optim_config=optim_config, materialization=MaterializationStrategy.PER_WORKER
     ).run()
 
-    # Verify materialization produces MaterializedTimeScenarioSeriesData
     mat_db = study.database.materialize([0])
     assert isinstance(mat_db.get_data("D", "demand"), MaterializedTimeScenarioSeriesData)
 
     obj_rows_lazy = lazy_table.data.loc[lazy_table.data["output"] == "objective-value", "value"]
     obj_rows_mat = mat_table.data.loc[mat_table.data["output"] == "objective-value", "value"]
     assert obj_rows_lazy.sum() == pytest.approx(obj_rows_mat.sum(), rel=1e-6)
+
+
+def test_materialize_upfront_same_result_as_lazy(tmp_path: Path) -> None:
+    """MaterializationStrategy.UPFRONT produces the same objective as NONE (lazy).
+
+    Loads the full database into RAM before the run loop starts.
+    All columns for all scenarios are materialized in one I/O pass.
+    """
+    study = _make_scenarized_study(tmp_path)
+    optim_config = _sequential_config()
+
+    lazy_table = SimulationSession(study=study, optim_config=optim_config).run()
+    upfront_table = SimulationSession(
+        study=study, optim_config=optim_config, materialization=MaterializationStrategy.UPFRONT
+    ).run()
+
+    mat_db = study.database.materialize(list(range(optim_config.scenario_scope.nb_scenarios)))
+    assert isinstance(mat_db.get_data("D", "demand"), MaterializedTimeScenarioSeriesData)
+
+    obj_rows_lazy = lazy_table.data.loc[lazy_table.data["output"] == "objective-value", "value"]
+    obj_rows_up = upfront_table.data.loc[upfront_table.data["output"] == "objective-value", "value"]
+    assert obj_rows_lazy.sum() == pytest.approx(obj_rows_up.sum(), rel=1e-6)

--- a/tests/unittests/data/test_data.py
+++ b/tests/unittests/data/test_data.py
@@ -17,11 +17,15 @@ from typing import Optional
 
 import numpy as np
 import pandas as pd
+import polars as pl
 import pytest
 
 from gems.study.data import (
     ConstantData,
     DataBase,
+    LazyScenarioSeriesData,
+    LazyTimeScenarioSeriesData,
+    LazyTimeSeriesData,
     ScenarioSeriesData,
     TimeScenarioSeriesData,
     TimeSeriesData,
@@ -32,6 +36,27 @@ from gems.study.data import (
 from gems.study.parsing import parse_yaml_components
 from gems.study.resolve_components import _build_data, build_data_base
 from gems.study.scenario_builder import ScenarioBuilder
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_time_scenario_parquet(path: Path, data: list[list[float]]) -> None:
+    """Write a T×S parquet with columns named "0", "1", …"""
+    n_cols = len(data[0])
+    pl.DataFrame({str(c): [row[c] for row in data] for c in range(n_cols)}).write_parquet(path)
+
+
+def _write_time_series_parquet(path: Path, values: list[float]) -> None:
+    """Write a T×1 parquet with a single column named "0"."""
+    pl.DataFrame({"0": values}).write_parquet(path)
+
+
+def _write_scenario_series_parquet(path: Path, values: list[float], n_rows: int = 3) -> None:
+    """Write an S-column parquet where every row holds the same scenario values."""
+    pl.DataFrame({str(c): [v] * n_rows for c, v in enumerate(values)}).write_parquet(path)
 
 # ---------------------------------------------------------------------------
 # load_ts_from_file
@@ -262,3 +287,193 @@ def test_database_get_data_missing_key_raises() -> None:
     db = DataBase()
     with pytest.raises(KeyError):
         db.get_data("unknown", "param")
+
+
+# ---------------------------------------------------------------------------
+# LazyTimeSeriesData
+# ---------------------------------------------------------------------------
+
+
+def test_lazy_time_series_data_basic(tmp_path: Path) -> None:
+    """Reads the requested timesteps from a parquet file."""
+    p = tmp_path / "ts.parquet"
+    _write_time_series_parquet(p, [10.0, 20.0, 30.0, 40.0])
+    lazy = LazyTimeSeriesData(str(p))
+    result = lazy.get_value([0, 2], None)
+    np.testing.assert_array_equal(result, [10.0, 30.0])
+
+
+def test_lazy_time_series_data_broadcast_over_scenarios(tmp_path: Path) -> None:
+    """Broadcasts time values across scenarios when scenario array is provided."""
+    p = tmp_path / "ts.parquet"
+    _write_time_series_parquet(p, [1.0, 2.0, 3.0])
+    lazy = LazyTimeSeriesData(str(p))
+    result = lazy.get_value([0, 1], np.array([0, 1, 2]))
+    assert result.shape == (2, 3)
+    np.testing.assert_array_equal(result[:, 0], [1.0, 2.0])
+    np.testing.assert_array_equal(result[:, 2], [1.0, 2.0])
+
+
+def test_lazy_time_series_data_requires_timestep(tmp_path: Path) -> None:
+    p = tmp_path / "ts.parquet"
+    _write_time_series_parquet(p, [1.0, 2.0])
+    with pytest.raises(KeyError):
+        LazyTimeSeriesData(str(p)).get_value(None, None)
+
+
+def test_lazy_time_series_data_check_requirement() -> None:
+    lazy = LazyTimeSeriesData("irrelevant.parquet")
+    assert lazy.check_requirement(time=True, scenario=False) is True
+    assert lazy.check_requirement(time=False, scenario=True) is False
+
+
+# ---------------------------------------------------------------------------
+# LazyScenarioSeriesData
+# ---------------------------------------------------------------------------
+
+
+def test_lazy_scenario_series_data_column_pruning(tmp_path: Path) -> None:
+    """Reads only the requested scenario columns."""
+    p = tmp_path / "sc.parquet"
+    _write_scenario_series_parquet(p, [100.0, 200.0, 300.0])
+    lazy = LazyScenarioSeriesData(str(p))
+    result = lazy.get_value(None, np.array([2, 0]))
+    np.testing.assert_array_equal(result, [300.0, 100.0])
+
+
+def test_lazy_scenario_series_data_broadcast_over_time(tmp_path: Path) -> None:
+    """Broadcasts scenario values across timesteps when timestep list is provided."""
+    p = tmp_path / "sc.parquet"
+    _write_scenario_series_parquet(p, [5.0, 10.0])
+    lazy = LazyScenarioSeriesData(str(p))
+    result = lazy.get_value([0, 1, 2], np.array([0, 1]))
+    assert result.shape == (3, 2)
+    np.testing.assert_array_equal(result[0], [5.0, 10.0])
+    np.testing.assert_array_equal(result[2], [5.0, 10.0])
+
+
+def test_lazy_scenario_series_data_requires_scenario(tmp_path: Path) -> None:
+    p = tmp_path / "sc.parquet"
+    _write_scenario_series_parquet(p, [1.0])
+    with pytest.raises(KeyError):
+        LazyScenarioSeriesData(str(p)).get_value([0], None)
+
+
+def test_lazy_scenario_series_data_check_requirement() -> None:
+    lazy = LazyScenarioSeriesData("irrelevant.parquet")
+    assert lazy.check_requirement(time=False, scenario=True) is True
+    assert lazy.check_requirement(time=True, scenario=False) is False
+
+
+# ---------------------------------------------------------------------------
+# LazyTimeScenarioSeriesData
+# ---------------------------------------------------------------------------
+
+
+def test_lazy_time_scenario_series_data_column_pruning(tmp_path: Path) -> None:
+    """Reads only the requested columns and rows."""
+    p = tmp_path / "tss.parquet"
+    # 3 timesteps × 4 scenarios
+    _write_time_scenario_parquet(p, [
+        [1.0, 2.0, 3.0, 4.0],
+        [5.0, 6.0, 7.0, 8.0],
+        [9.0, 10.0, 11.0, 12.0],
+    ])
+    lazy = LazyTimeScenarioSeriesData(str(p))
+    result = lazy.get_value([0, 2], np.array([1, 3]))
+    assert result.shape == (2, 2)
+    np.testing.assert_array_equal(result, [[2.0, 4.0], [10.0, 12.0]])
+
+
+def test_lazy_time_scenario_series_data_requires_timestep(tmp_path: Path) -> None:
+    p = tmp_path / "tss.parquet"
+    _write_time_scenario_parquet(p, [[1.0, 2.0]])
+    with pytest.raises(KeyError):
+        LazyTimeScenarioSeriesData(str(p)).get_value(None, np.array([0]))
+
+
+def test_lazy_time_scenario_series_data_requires_scenario(tmp_path: Path) -> None:
+    p = tmp_path / "tss.parquet"
+    _write_time_scenario_parquet(p, [[1.0, 2.0]])
+    with pytest.raises(KeyError):
+        LazyTimeScenarioSeriesData(str(p)).get_value([0], None)
+
+
+def test_lazy_time_scenario_series_data_check_requirement() -> None:
+    lazy = LazyTimeScenarioSeriesData("irrelevant.parquet")
+    assert lazy.check_requirement(time=True, scenario=True) is True
+    assert lazy.check_requirement(time=True, scenario=False) is False
+    assert lazy.check_requirement(time=False, scenario=True) is False
+
+
+# ---------------------------------------------------------------------------
+# _build_data — parquet format detection and backward compat
+# ---------------------------------------------------------------------------
+
+
+def test_build_data_detects_parquet_time_scenario(tmp_path: Path) -> None:
+    """Returns LazyTimeScenarioSeriesData when a .parquet file is present."""
+    p = tmp_path / "series.parquet"
+    _write_time_scenario_parquet(p, [[1.0, 2.0], [3.0, 4.0]])
+    result = _build_data(
+        time_dependent=True,
+        scenario_dependent=True,
+        param_value="series",
+        timeseries_dir=tmp_path,
+    )
+    assert isinstance(result, LazyTimeScenarioSeriesData)
+    assert result.uri == str(p)
+
+
+def test_build_data_detects_parquet_time_only(tmp_path: Path) -> None:
+    """Returns LazyTimeSeriesData when a .parquet file is present."""
+    p = tmp_path / "series.parquet"
+    _write_time_series_parquet(p, [1.0, 2.0, 3.0])
+    result = _build_data(
+        time_dependent=True,
+        scenario_dependent=False,
+        param_value="series",
+        timeseries_dir=tmp_path,
+    )
+    assert isinstance(result, LazyTimeSeriesData)
+    assert result.uri == str(p)
+
+
+def test_build_data_detects_parquet_scenario_only(tmp_path: Path) -> None:
+    """Returns LazyScenarioSeriesData when a .parquet file is present."""
+    p = tmp_path / "series.parquet"
+    _write_scenario_series_parquet(p, [10.0, 20.0])
+    result = _build_data(
+        time_dependent=False,
+        scenario_dependent=True,
+        param_value="series",
+        timeseries_dir=tmp_path,
+    )
+    assert isinstance(result, LazyScenarioSeriesData)
+    assert result.uri == str(p)
+
+
+def test_build_data_falls_back_to_txt_when_no_parquet(tmp_path: Path) -> None:
+    """Falls back to eager TimeScenarioSeriesData when only a .txt file exists."""
+    (tmp_path / "series.txt").write_text("1 2\n3 4\n")
+    result = _build_data(
+        time_dependent=True,
+        scenario_dependent=True,
+        param_value="series",
+        timeseries_dir=tmp_path,
+    )
+    assert isinstance(result, TimeScenarioSeriesData)
+
+
+def test_build_data_parquet_takes_precedence_over_txt(tmp_path: Path) -> None:
+    """Parquet file wins when both .parquet and .txt exist."""
+    (tmp_path / "series.txt").write_text("1 2\n3 4\n")
+    p = tmp_path / "series.parquet"
+    _write_time_scenario_parquet(p, [[1.0, 2.0], [3.0, 4.0]])
+    result = _build_data(
+        time_dependent=True,
+        scenario_dependent=True,
+        param_value="series",
+        timeseries_dir=tmp_path,
+    )
+    assert isinstance(result, LazyTimeScenarioSeriesData)

--- a/tests/unittests/data/test_data.py
+++ b/tests/unittests/data/test_data.py
@@ -26,6 +26,7 @@ from gems.study.data import (
     LazyScenarioSeriesData,
     LazyTimeScenarioSeriesData,
     LazyTimeSeriesData,
+    MaterializedTimeScenarioSeriesData,
     ScenarioSeriesData,
     TimeScenarioSeriesData,
     TimeSeriesData,
@@ -36,7 +37,6 @@ from gems.study.data import (
 from gems.study.parsing import parse_yaml_components
 from gems.study.resolve_components import _build_data, build_data_base
 from gems.study.scenario_builder import ScenarioBuilder
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -57,6 +57,7 @@ def _write_time_series_parquet(path: Path, values: list[float]) -> None:
 def _write_scenario_series_parquet(path: Path, values: list[float], n_rows: int = 3) -> None:
     """Write an S-column parquet where every row holds the same scenario values."""
     pl.DataFrame({str(c): [v] * n_rows for c, v in enumerate(values)}).write_parquet(path)
+
 
 # ---------------------------------------------------------------------------
 # load_ts_from_file
@@ -374,11 +375,14 @@ def test_lazy_time_scenario_series_data_column_pruning(tmp_path: Path) -> None:
     """Reads only the requested columns and rows."""
     p = tmp_path / "tss.parquet"
     # 3 timesteps × 4 scenarios
-    _write_time_scenario_parquet(p, [
-        [1.0, 2.0, 3.0, 4.0],
-        [5.0, 6.0, 7.0, 8.0],
-        [9.0, 10.0, 11.0, 12.0],
-    ])
+    _write_time_scenario_parquet(
+        p,
+        [
+            [1.0, 2.0, 3.0, 4.0],
+            [5.0, 6.0, 7.0, 8.0],
+            [9.0, 10.0, 11.0, 12.0],
+        ],
+    )
     lazy = LazyTimeScenarioSeriesData(str(p))
     result = lazy.get_value([0, 2], np.array([1, 3]))
     assert result.shape == (2, 2)
@@ -477,3 +481,132 @@ def test_build_data_parquet_takes_precedence_over_txt(tmp_path: Path) -> None:
         timeseries_dir=tmp_path,
     )
     assert isinstance(result, LazyTimeScenarioSeriesData)
+
+
+# ---------------------------------------------------------------------------
+# MaterializedTimeScenarioSeriesData
+# ---------------------------------------------------------------------------
+
+
+def test_materialized_time_scenario_get_value_basic() -> None:
+    """get_value returns the correct (T, S) slice from selectively pre-loaded data.
+
+    Original file had 3 columns (0, 1, 2); only cols 0 and 2 were loaded.
+    Position 0 in data → original col 0, position 1 → original col 2.
+    """
+    # data holds only the two loaded columns (original cols 0 and 2)
+    data = np.array([[1.0, 3.0], [4.0, 6.0], [7.0, 9.0]])
+    col_pos = {0: 0, 2: 1}
+    mat = MaterializedTimeScenarioSeriesData(data=data, col_pos=col_pos)
+    result = mat.get_value([0, 2], np.array([0, 2]))
+    np.testing.assert_array_equal(result, [[1.0, 3.0], [7.0, 9.0]])
+
+
+def test_materialized_time_scenario_get_value_duplicate_scenarios() -> None:
+    """Duplicate scenario indices are handled via col_pos remapping."""
+    data = np.array([[10.0, 20.0]])
+    col_pos = {0: 0, 5: 1}
+    mat = MaterializedTimeScenarioSeriesData(data=data, col_pos=col_pos)
+    result = mat.get_value([0], np.array([5, 0, 5]))
+    np.testing.assert_array_equal(result, [[20.0, 10.0, 20.0]])
+
+
+def test_materialized_time_scenario_requires_timestep() -> None:
+    mat = MaterializedTimeScenarioSeriesData(data=np.zeros((2, 2)), col_pos={0: 0, 1: 1})
+    with pytest.raises(KeyError):
+        mat.get_value(None, np.array([0]))
+
+
+def test_materialized_time_scenario_requires_scenario() -> None:
+    mat = MaterializedTimeScenarioSeriesData(data=np.zeros((2, 2)), col_pos={0: 0, 1: 1})
+    with pytest.raises(KeyError):
+        mat.get_value([0], None)
+
+
+def test_materialized_time_scenario_check_requirement() -> None:
+    mat = MaterializedTimeScenarioSeriesData(data=np.zeros((1, 1)), col_pos={0: 0})
+    assert mat.check_requirement(time=True, scenario=True) is True
+    assert mat.check_requirement(time=False, scenario=True) is False
+    assert mat.check_requirement(time=True, scenario=False) is False
+
+
+# ---------------------------------------------------------------------------
+# DataBase.materialize
+# ---------------------------------------------------------------------------
+
+
+def test_database_materialize_lazy_time_scenario_becomes_materialized(tmp_path: Path) -> None:
+    """LazyTimeScenarioSeriesData entries are replaced by MaterializedTimeScenarioSeriesData."""
+    p = tmp_path / "s.parquet"
+    _write_time_scenario_parquet(p, [[1.0, 2.0], [3.0, 4.0]])
+    db = DataBase()
+    db.add_data("C", "p", LazyTimeScenarioSeriesData(str(p)))
+    mat_db = db.materialize([0])
+    entry = mat_db.get_data("C", "p")
+    assert isinstance(entry, MaterializedTimeScenarioSeriesData)
+    result = entry.get_value([0, 1], np.array([0]))
+    np.testing.assert_allclose(result, [[1.0], [3.0]])
+
+
+def test_database_materialize_lazy_time_series_becomes_eager(tmp_path: Path) -> None:
+    """LazyTimeSeriesData entries are replaced by TimeSeriesData."""
+    p = tmp_path / "s.parquet"
+    _write_time_series_parquet(p, [10.0, 20.0])
+    db = DataBase()
+    db.add_data("C", "p", LazyTimeSeriesData(str(p)))
+    mat_db = db.materialize([0])
+    assert isinstance(mat_db.get_data("C", "p"), TimeSeriesData)
+
+
+def test_database_materialize_lazy_scenario_series_becomes_eager(tmp_path: Path) -> None:
+    """LazyScenarioSeriesData entries are replaced by ScenarioSeriesData."""
+    p = tmp_path / "s.parquet"
+    _write_scenario_series_parquet(p, [5.0, 10.0])
+    db = DataBase()
+    db.add_data("C", "p", LazyScenarioSeriesData(str(p)))
+    mat_db = db.materialize([0, 1])
+    assert isinstance(mat_db.get_data("C", "p"), ScenarioSeriesData)
+
+
+def test_database_materialize_eager_entries_carried_over() -> None:
+    """Eager entries are carried over unchanged."""
+    db = DataBase()
+    db.add_data("C", "p", ConstantData(42.0))
+    mat_db = db.materialize([0])
+    assert isinstance(mat_db.get_data("C", "p"), ConstantData)
+
+
+def test_database_materialize_does_not_mutate_original(tmp_path: Path) -> None:
+    """materialize() returns a new DataBase; the original keeps lazy entries."""
+    p = tmp_path / "s.parquet"
+    _write_time_series_parquet(p, [1.0, 2.0])
+    db = DataBase()
+    db.add_data("C", "p", LazyTimeSeriesData(str(p)))
+    _ = db.materialize([0])
+    assert isinstance(db.get_data("C", "p"), LazyTimeSeriesData)
+
+
+def test_database_materialize_selective_columns(tmp_path: Path) -> None:
+    """Only the scenario columns needed by mc_scenario_ids are loaded."""
+    p = tmp_path / "s.parquet"
+    _write_time_scenario_parquet(p, [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+    db = DataBase()
+    db.add_data("C", "p", LazyTimeScenarioSeriesData(str(p)))
+    mat_db = db.materialize([2])  # only mc scenario 2 → data col 2
+    entry = mat_db.get_data("C", "p")
+    assert isinstance(entry, MaterializedTimeScenarioSeriesData)
+    assert set(entry.col_pos.keys()) == {2}
+
+
+def test_database_materialize_with_scenario_builder(tmp_path: Path) -> None:
+    """ScenarioBuilder column resolution feeds the selective materialization."""
+    p = tmp_path / "s.parquet"
+    _write_time_scenario_parquet(p, [[10.0, 20.0], [30.0, 40.0]])
+    # MC scenarios 0,1,2 → data cols 1,0,1 (both cols 0 and 1 needed)
+    builder = ScenarioBuilder({"grp": np.array([1, 0, 1])})
+    db = DataBase(scenario_builder=builder)
+    db.add_data("C", "p", LazyTimeScenarioSeriesData(str(p)), scenario_group="grp")
+    mat_db = db.materialize([0, 1, 2])
+    entry = mat_db.get_data("C", "p")
+    assert isinstance(entry, MaterializedTimeScenarioSeriesData)
+    assert set(entry.col_pos.keys()) == {0, 1}

--- a/uv.lock
+++ b/uv.lock
@@ -678,7 +678,7 @@ wheels = [
 
 [[package]]
 name = "gemspy"
-version = "0.0.6"
+version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "antlr4-python3-runtime" },
@@ -690,6 +690,7 @@ dependencies = [
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "pandas", version = "3.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "polars" },
     { name = "pydantic" },
     { name = "pyyaml" },
     { name = "xarray", version = "2025.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -732,6 +733,7 @@ requires-dist = [
     { name = "mkdocstrings-python", marker = "extra == 'doc'" },
     { name = "numpy", specifier = ">=1.26" },
     { name = "pandas", specifier = ">=2.2" },
+    { name = "polars", specifier = ">=1.0" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "xarray", specifier = ">=2025.3" },


### PR DESCRIPTION
## Overview

Introduces a Polars-backed lazy loading path for time-series data stored as Parquet files, alongside a pluggable `Executor` for parallel subproblem execution and a `MaterializationStrategy` enum to control when and how much data is loaded into RAM.

## New data structures (`gems/study/data.py`)

Three new `AbstractDataStructure` subclasses defer parquet I/O to `get_value()` call time:

| Class | Parquet layout | Polars optimisation |
|---|---|---|
| `LazyTimeSeriesData` | 1 column `"0"`, T rows | row indexing deferred |
| `LazyScenarioSeriesData` | S columns `"0"`…`"S-1"`, 1 effective row | `.head(1)` + column pruning |
| `LazyTimeScenarioSeriesData` | S columns, T rows | column pruning — only requested scenarios read |

A fourth class handles the materialized case:

- **`MaterializedTimeScenarioSeriesData`** — holds a pre-loaded `(T, n_cols)` numpy array for a worker's scenario subset. Carries a pre-built dense lookup array so column remapping is a single vectorized numpy index rather than a Python loop.

All `get_value` implementations use `np.unique(..., return_inverse=True)` for duplicate-scenario deduplication, replacing the previous Python dict-loop pattern.

### `DataBase.materialize(mc_scenario_ids)`

Returns a new `DataBase` with every lazy entry replaced by in-memory data. Only the data-series columns actually needed by the given MC scenario IDs are read from each parquet file (via `ScenarioBuilder` when present). Eager entries are carried over unchanged. The original `DataBase` is never mutated.

### Parquet detection and backward compatibility

`_build_data()` checks for a `.parquet` file first; falls back transparently to the existing `.txt` / `.tsv` eager path when none is present. Both formats can coexist in the same directory — parquet always takes precedence.

## `MaterializationStrategy` enum (`gems/session/session.py`)

Replaces the previous `materialize_per_worker: bool` field with a three-value enum:

| Value | Behaviour |
|---|---|
| `NONE` (default) | Lazy I/O on every `get_value` call |
| `UPFRONT` | Full database loaded into RAM once before the run loop starts |
| `PER_WORKER` | Each scenario (sequential) or batch (parallel) materializes only its own columns |

`UPFRONT` is the right choice when data fits comfortably in RAM and I/O is expensive relative to compute (e.g. network-attached storage). `PER_WORKER` is the right choice for distributed workers where minimal per-worker RAM footprint matters. `NONE` is appropriate when parquet files are local and small relative to the time horizon.

## Pluggable executor (`SimulationSession`)

`SimulationSession` gains an optional `executor: concurrent.futures.Executor` field:

- **Sequential mode** — each scenario is submitted as an independent task; `None` runs them in the calling thread.
- **Parallel mode** — `(block, scenario)` work items are grouped into batches and submitted concurrently. `_run_batch` receives the (possibly pre-materialized) study as an explicit argument.

The lazy data structures are cheaply picklable (URI strings only), so remote workers (Ray, `ProcessPoolExecutor`) receive near-zero serialisation overhead.

## Thread safety (`Study.__post_init__`)

`Study.model_components` and `Study.models` are `cached_property` fields. Pre-populating them in `__post_init__` ensures concurrent workers only ever perform reads, eliminating the racy first-write through `cached_property.__set_name__`.

## Tests

- **`tests/unittests/data/test_data.py`** — 13 new tests covering `MaterializedTimeScenarioSeriesData` (get_value, duplicates, missing keys, check_requirement) and `DataBase.materialize` (all lazy types, eager carry-over, immutability, selective columns, ScenarioBuilder mapping).
- **`tests/e2e/functional/test_parquet_dataseries.py`** — 6 tests: one per lazy type, parquet-takes-precedence, `PER_WORKER`, and `UPFRONT`.
- **`tests/e2e/functional/test_parquet_complex_study.py`** — 2 study-level comparison tests on the 7_4 study (12 components, 168 timesteps): parquet+tsv coexistence and parquet-only mode, both asserting numerical identity with the TSV reference run.

https://claude.ai/code/session_01GYyht7zSYAB5m4V9mL2cB5