### PR TITLE
feat/ add operators abs & round

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to GemsPy are documented here.
 
+## [Unreleased]
+
+### Added
+- Math operators `abs` and `round` in the GemsPy expression language.
+  - Can be applied to parameters and literals in constraints, bounds, and objective contributions (degree-0 context).
+  - Can be applied to any expression in extra-outputs (post-solve evaluation), including decision variables.
+  - Use `.abs()` and `.round()` methods on expression objects, or `abs(expr)` and `round(expr)` in parsed expression strings.
+
+---
+
 ## [0.1.1] - 2026-05-29
 
 ### Scenario-scope playlist (replaces `nb-scenarios`)

--- a/src/gems/expression/__init__.py
+++ b/src/gems/expression/__init__.py
@@ -14,6 +14,7 @@ from .copy import CopyVisitor, copy_expression
 from .degree import ExpressionDegreeVisitor, compute_degree
 from .evaluate import EvaluationContext, EvaluationVisitor, ValueProvider, evaluate
 from .expression import (
+    AbsNode,
     AdditionNode,
     CeilNode,
     Comparator,
@@ -27,6 +28,7 @@ from .expression import (
     MultiplicationNode,
     NegationNode,
     ParameterNode,
+    RoundNode,
     VariableNode,
     literal,
     maximum,

--- a/src/gems/expression/copy.py
+++ b/src/gems/expression/copy.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass
 from typing import List, cast
 
 from .expression import (
+    AbsNode,
     AdditionNode,
     AllTimeSumNode,
     CeilNode,
@@ -26,6 +27,7 @@ from .expression import (
     ParameterNode,
     PortFieldAggregatorNode,
     PortFieldNode,
+    RoundNode,
     ScenarioOperatorNode,
     TimeEvalNode,
     TimeShiftNode,
@@ -88,6 +90,12 @@ class CopyVisitor(ExpressionVisitorOperations[ExpressionNode]):
 
     def ceil(self, node: CeilNode) -> ExpressionNode:
         return CeilNode(visit(node.operand, self))
+
+    def abs(self, node: AbsNode) -> ExpressionNode:
+        return AbsNode(visit(node.operand, self))
+
+    def round(self, node: RoundNode) -> ExpressionNode:
+        return RoundNode(visit(node.operand, self))
 
     def maximum(self, node: MaxNode) -> ExpressionNode:
         return MaxNode([visit(op, self) for op in node.operands])

--- a/src/gems/expression/degree.py
+++ b/src/gems/expression/degree.py
@@ -14,6 +14,7 @@ import math
 
 import gems.expression.scenario_operator
 from gems.expression.expression import (
+    AbsNode,
     AllTimeSumNode,
     CeilNode,
     FloorNode,
@@ -21,6 +22,7 @@ from gems.expression.expression import (
     MinNode,
     PortFieldAggregatorNode,
     PortFieldNode,
+    RoundNode,
     TimeEvalNode,
     TimeShiftNode,
     TimeSumNode,
@@ -103,6 +105,14 @@ class ExpressionDegreeVisitor(ExpressionVisitor[int | float]):
         return 0 if d == 0 else math.inf
 
     def ceil(self, node: CeilNode) -> int | float:
+        d = visit(node.operand, self)
+        return 0 if d == 0 else math.inf
+
+    def abs(self, node: AbsNode) -> int | float:
+        d = visit(node.operand, self)
+        return 0 if d == 0 else math.inf
+
+    def round(self, node: RoundNode) -> int | float:
         d = visit(node.operand, self)
         return 0 if d == 0 else math.inf
 

--- a/src/gems/expression/equality.py
+++ b/src/gems/expression/equality.py
@@ -26,6 +26,7 @@ from gems.expression import (
     VariableNode,
 )
 from gems.expression.expression import (
+    AbsNode,
     AllTimeSumNode,
     BinaryOperatorNode,
     CeilNode,
@@ -34,6 +35,7 @@ from gems.expression.expression import (
     MinNode,
     PortFieldAggregatorNode,
     PortFieldNode,
+    RoundNode,
     ScenarioOperatorNode,
     TimeEvalNode,
     TimeShiftNode,
@@ -99,6 +101,10 @@ class EqualityVisitor:
             return self.floor(left, right)
         if isinstance(left, CeilNode) and isinstance(right, CeilNode):
             return self.ceil(left, right)
+        if isinstance(left, AbsNode) and isinstance(right, AbsNode):
+            return self.abs(left, right)
+        if isinstance(left, RoundNode) and isinstance(right, RoundNode):
+            return self.round(left, right)
         if isinstance(left, MaxNode) and isinstance(right, MaxNode):
             return self.maximum(left, right)
         if isinstance(left, MinNode) and isinstance(right, MinNode):
@@ -181,6 +187,12 @@ class EqualityVisitor:
         return self.visit(left.operand, right.operand)
 
     def ceil(self, left: CeilNode, right: CeilNode) -> bool:
+        return self.visit(left.operand, right.operand)
+
+    def abs(self, left: AbsNode, right: AbsNode) -> bool:
+        return self.visit(left.operand, right.operand)
+
+    def round(self, left: RoundNode, right: RoundNode) -> bool:
         return self.visit(left.operand, right.operand)
 
     def maximum(self, left: MaxNode, right: MaxNode) -> bool:

--- a/src/gems/expression/evaluate.py
+++ b/src/gems/expression/evaluate.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass, field
 from typing import Dict
 
 from gems.expression.expression import (
+    AbsNode,
     AllTimeSumNode,
     CeilNode,
     FloorNode,
@@ -23,6 +24,7 @@ from gems.expression.expression import (
     MinNode,
     PortFieldAggregatorNode,
     PortFieldNode,
+    RoundNode,
     TimeEvalNode,
     TimeShiftNode,
     TimeSumNode,
@@ -117,6 +119,12 @@ class EvaluationVisitor(ExpressionVisitorOperations[float]):
 
     def ceil(self, node: CeilNode) -> float:
         return float(math.ceil(visit(node.operand, self)))
+
+    def abs(self, node: AbsNode) -> float:
+        return abs(visit(node.operand, self))
+
+    def round(self, node: RoundNode) -> float:
+        return float(round(visit(node.operand, self)))
 
     def maximum(self, node: MaxNode) -> float:
         return max(visit(op, self) for op in node.operands)

--- a/src/gems/expression/evaluate.py
+++ b/src/gems/expression/evaluate.py
@@ -121,10 +121,12 @@ class EvaluationVisitor(ExpressionVisitorOperations[float]):
         return float(math.ceil(visit(node.operand, self)))
 
     def abs(self, node: AbsNode) -> float:
-        return abs(visit(node.operand, self))
+        value: float = visit(node.operand, self)
+        return abs(value)
 
     def round(self, node: RoundNode) -> float:
-        return float(round(visit(node.operand, self)))
+        value: float = visit(node.operand, self)
+        return float(round(value))
 
     def maximum(self, node: MaxNode) -> float:
         return max(visit(op, self) for op in node.operands)

--- a/src/gems/expression/expression.py
+++ b/src/gems/expression/expression.py
@@ -124,6 +124,12 @@ class ExpressionNode:
     def ceil(self) -> "ExpressionNode":
         return CeilNode(self)
 
+    def abs(self) -> "ExpressionNode":
+        return AbsNode(self)
+
+    def round(self) -> "ExpressionNode":
+        return RoundNode(self)
+
     def expec(self) -> "ExpressionNode":
         return _apply_if_node(self, lambda x: ScenarioOperatorNode(x, "Expectation"))
 
@@ -232,6 +238,18 @@ class FloorNode(UnaryOperatorNode):
 
 @dataclass(frozen=True, eq=False)
 class CeilNode(UnaryOperatorNode):
+    pass
+
+
+@dataclass(frozen=True, eq=False)
+class AbsNode(UnaryOperatorNode):
+    pass
+
+
+@dataclass(frozen=True, eq=False)
+class RoundNode(UnaryOperatorNode):
+    """Round to nearest integer using banker's rounding (np.round / Python 3 round)."""
+
     pass
 
 

--- a/src/gems/expression/indexing.py
+++ b/src/gems/expression/indexing.py
@@ -17,6 +17,7 @@ from typing import List
 from gems.expression.indexing_structure import IndexingStructure
 
 from .expression import (
+    AbsNode,
     AdditionNode,
     AllTimeSumNode,
     CeilNode,
@@ -32,6 +33,7 @@ from .expression import (
     ParameterNode,
     PortFieldAggregatorNode,
     PortFieldNode,
+    RoundNode,
     ScenarioOperatorNode,
     TimeEvalNode,
     TimeShiftNode,
@@ -129,6 +131,12 @@ class TimeScenarioIndexingVisitor(ExpressionVisitor[IndexingStructure]):
         return visit(node.operand, self)
 
     def ceil(self, node: CeilNode) -> IndexingStructure:
+        return visit(node.operand, self)
+
+    def abs(self, node: AbsNode) -> IndexingStructure:
+        return visit(node.operand, self)
+
+    def round(self, node: RoundNode) -> IndexingStructure:
         return visit(node.operand, self)
 
     def maximum(self, node: MaxNode) -> IndexingStructure:

--- a/src/gems/expression/parsing/parse_expression.py
+++ b/src/gems/expression/parsing/parse_expression.py
@@ -265,6 +265,8 @@ _UNARY_FUNCTIONS = {
     "expec": ExpressionNode.expec,
     "floor": ExpressionNode.floor,
     "ceil": ExpressionNode.ceil,
+    "abs": ExpressionNode.abs,
+    "round": ExpressionNode.round,
 }
 
 _N_ARY_FUNCTIONS = {

--- a/src/gems/expression/print.py
+++ b/src/gems/expression/print.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass
 from typing import Dict
 
 from gems.expression.expression import (
+    AbsNode,
     AllTimeSumNode,
     CeilNode,
     ExpressionNode,
@@ -22,6 +23,7 @@ from gems.expression.expression import (
     MinNode,
     PortFieldAggregatorNode,
     PortFieldNode,
+    RoundNode,
     TimeEvalNode,
     TimeShiftNode,
     TimeSumNode,
@@ -121,6 +123,12 @@ class PrinterVisitor(ExpressionVisitor[str]):
 
     def ceil(self, node: CeilNode) -> str:
         return f"ceil({visit(node.operand, self)})"
+
+    def abs(self, node: AbsNode) -> str:
+        return f"abs({visit(node.operand, self)})"
+
+    def round(self, node: RoundNode) -> str:
+        return f"round({visit(node.operand, self)})"
 
     def maximum(self, node: MaxNode) -> str:
         return "max(" + ", ".join(visit(op, self) for op in node.operands) + ")"

--- a/src/gems/expression/visitor.py
+++ b/src/gems/expression/visitor.py
@@ -19,6 +19,7 @@ from abc import ABC, abstractmethod
 from typing import Generic, Protocol, TypeVar
 
 from gems.expression.expression import (
+    AbsNode,
     AdditionNode,
     AllTimeSumNode,
     CeilNode,
@@ -34,6 +35,7 @@ from gems.expression.expression import (
     ParameterNode,
     PortFieldAggregatorNode,
     PortFieldNode,
+    RoundNode,
     ScenarioOperatorNode,
     TimeEvalNode,
     TimeShiftNode,
@@ -105,6 +107,12 @@ class ExpressionVisitor(ABC, Generic[T]):
     def ceil(self, node: CeilNode) -> T: ...
 
     @abstractmethod
+    def abs(self, node: AbsNode) -> T: ...
+
+    @abstractmethod
+    def round(self, node: RoundNode) -> T: ...
+
+    @abstractmethod
     def maximum(self, node: MaxNode) -> T: ...
 
     @abstractmethod
@@ -149,6 +157,10 @@ def visit(root: ExpressionNode, visitor: ExpressionVisitor[T]) -> T:
         return visitor.floor(root)
     elif isinstance(root, CeilNode):
         return visitor.ceil(root)
+    elif isinstance(root, AbsNode):
+        return visitor.abs(root)
+    elif isinstance(root, RoundNode):
+        return visitor.round(root)
     elif isinstance(root, MaxNode):
         return visitor.maximum(root)
     elif isinstance(root, MinNode):

--- a/src/gems/model/port.py
+++ b/src/gems/model/port.py
@@ -26,6 +26,7 @@ from gems.expression import (
     VariableNode,
 )
 from gems.expression.expression import (
+    AbsNode,
     AllTimeSumNode,
     BinaryOperatorNode,
     CeilNode,
@@ -34,6 +35,7 @@ from gems.expression.expression import (
     MinNode,
     PortFieldAggregatorNode,
     PortFieldNode,
+    RoundNode,
     ScenarioOperatorNode,
     TimeEvalNode,
     TimeShiftNode,
@@ -149,6 +151,12 @@ class _PortFieldExpressionChecker(ExpressionVisitor[None]):
         visit(node.operand, self)
 
     def ceil(self, node: CeilNode) -> None:
+        visit(node.operand, self)
+
+    def abs(self, node: AbsNode) -> None:
+        visit(node.operand, self)
+
+    def round(self, node: RoundNode) -> None:
         visit(node.operand, self)
 
     def maximum(self, node: MaxNode) -> None:

--- a/src/gems/simulation/linearize.py
+++ b/src/gems/simulation/linearize.py
@@ -31,11 +31,13 @@ import numpy as np
 import xarray as xr
 
 from gems.expression.expression import (
+    AbsNode,
     AdditionNode,
     CeilNode,
     FloorNode,
     MaxNode,
     MinNode,
+    RoundNode,
     VariableNode,
 )
 from gems.expression.visitor import visit
@@ -125,6 +127,24 @@ class VectorizedLinearExprBuilder(VectorizedBuilderBase[VectorizedExpr]):
             return np.ceil(operand)  # type: ignore[return-value]
         raise NotImplementedError(
             "ceil() is only supported for parameter (DataArray) expressions; "
+            "it cannot be used with decision variables in a linear programme."
+        )
+
+    def abs(self, node: AbsNode) -> VectorizedExpr:
+        operand = visit(node.operand, self)
+        if isinstance(operand, xr.DataArray):
+            return np.abs(operand)  # type: ignore[return-value]
+        raise NotImplementedError(
+            "abs() is only supported for parameter (DataArray) expressions; "
+            "it cannot be used with decision variables in a linear programme."
+        )
+
+    def round(self, node: RoundNode) -> VectorizedExpr:
+        operand = visit(node.operand, self)
+        if isinstance(operand, xr.DataArray):
+            return np.round(operand)  # type: ignore[return-value]
+        raise NotImplementedError(
+            "round() is only supported for parameter (DataArray) expressions; "
             "it cannot be used with decision variables in a linear programme."
         )
 

--- a/src/gems/simulation/vectorized_builder.py
+++ b/src/gems/simulation/vectorized_builder.py
@@ -42,6 +42,7 @@ import xarray as xr
 
 from gems.expression.evaluate import EvaluationContext, EvaluationVisitor
 from gems.expression.expression import (
+    AbsNode,
     AdditionNode,
     AllTimeSumNode,
     CeilNode,
@@ -57,6 +58,7 @@ from gems.expression.expression import (
     ParameterNode,
     PortFieldAggregatorNode,
     PortFieldNode,
+    RoundNode,
     ScenarioOperatorNode,
     TimeEvalNode,
     TimeShiftNode,
@@ -368,6 +370,14 @@ class VectorizedBuilderBase(ExpressionVisitor[VectorizedExpr], Generic[T_expr]):
         operand = visit(node.operand, self)
         return np.ceil(operand)  # type: ignore[return-value,arg-type,call-overload]
 
+    def abs(self, node: AbsNode) -> VectorizedExpr:
+        operand = visit(node.operand, self)
+        return np.abs(operand)  # type: ignore[return-value,arg-type,call-overload]
+
+    def round(self, node: RoundNode) -> VectorizedExpr:
+        operand = visit(node.operand, self)
+        return np.round(operand)  # type: ignore[return-value,arg-type,call-overload]
+
     def maximum(self, node: MaxNode) -> VectorizedExpr:
         operands = [visit(op, self) for op in node.operands]
         result = operands[0]
@@ -525,6 +535,12 @@ class _ShiftAmountEvaluator(ExpressionVisitorOperations[xr.DataArray]):
     def ceil(self, node: CeilNode) -> xr.DataArray:
         return np.ceil(visit(node.operand, self))  # type: ignore[return-value]
 
+    def abs(self, node: AbsNode) -> xr.DataArray:
+        return np.abs(visit(node.operand, self))  # type: ignore[return-value]
+
+    def round(self, node: RoundNode) -> xr.DataArray:
+        return np.round(visit(node.operand, self))  # type: ignore[return-value]
+
     def maximum(self, node: MaxNode) -> xr.DataArray:
         ops = [visit(op, self) for op in node.operands]
         return functools.reduce(
@@ -652,6 +668,12 @@ class ShiftValidityVisitor(ExpressionVisitor[Optional[xr.DataArray]]):
         return visit(node.operand, self)
 
     def ceil(self, node: CeilNode) -> Optional[xr.DataArray]:
+        return visit(node.operand, self)
+
+    def abs(self, node: AbsNode) -> Optional[xr.DataArray]:
+        return visit(node.operand, self)
+
+    def round(self, node: RoundNode) -> Optional[xr.DataArray]:
         return visit(node.operand, self)
 
     def maximum(self, node: MaxNode) -> Optional[xr.DataArray]:

--- a/tests/unittests/expressions/parsing/test_expression_parsing.py
+++ b/tests/unittests/expressions/parsing/test_expression_parsing.py
@@ -133,6 +133,36 @@ from gems.expression.parsing.parse_expression import (
         ),
         (
             {},
+            {"p"},
+            "abs(p)",
+            param("p").abs(),
+        ),
+        (
+            {},
+            {"p"},
+            "round(p)",
+            param("p").round(),
+        ),
+        (
+            {},
+            {"p", "q"},
+            "abs(p - q)",
+            (param("p") - param("q")).abs(),
+        ),
+        (
+            {},
+            {"p", "q"},
+            "round(p / q)",
+            (param("p") / param("q")).round(),
+        ),
+        (
+            {},
+            {"p", "q"},
+            "max(0, abs(p - q))",
+            maximum(literal(0), (param("p") - param("q")).abs()),
+        ),
+        (
+            {},
             {"a", "b"},
             "max(a, b)",
             maximum(param("a"), param("b")),

--- a/tests/unittests/expressions/visitor/test_degree.py
+++ b/tests/unittests/expressions/visitor/test_degree.py
@@ -55,7 +55,6 @@ def test_abs_round_degree() -> None:
     assert visit(RoundNode(p), ExpressionDegreeVisitor()) == 0
     assert visit(AbsNode(x), ExpressionDegreeVisitor()) == math.inf
     assert visit(RoundNode(x), ExpressionDegreeVisitor()) == math.inf
-    # On a degree-0 sub-expression (e.g. p - q), still degree 0.
     assert visit(AbsNode(p - param("q")), ExpressionDegreeVisitor()) == 0
 
 

--- a/tests/unittests/expressions/visitor/test_degree.py
+++ b/tests/unittests/expressions/visitor/test_degree.py
@@ -23,7 +23,7 @@ from gems.expression import (
     var,
     visit,
 )
-from gems.expression.expression import CeilNode, FloorNode
+from gems.expression.expression import AbsNode, CeilNode, FloorNode, RoundNode
 
 
 def test_degree() -> None:
@@ -45,6 +45,18 @@ def test_floor_ceil_degree() -> None:
     assert visit(CeilNode(p), ExpressionDegreeVisitor()) == 0
     assert visit(FloorNode(x), ExpressionDegreeVisitor()) == math.inf
     assert visit(CeilNode(x), ExpressionDegreeVisitor()) == math.inf
+
+
+def test_abs_round_degree() -> None:
+    x = var("x")
+    p = param("p")
+
+    assert visit(AbsNode(p), ExpressionDegreeVisitor()) == 0
+    assert visit(RoundNode(p), ExpressionDegreeVisitor()) == 0
+    assert visit(AbsNode(x), ExpressionDegreeVisitor()) == math.inf
+    assert visit(RoundNode(x), ExpressionDegreeVisitor()) == math.inf
+    # On a degree-0 sub-expression (e.g. p - q), still degree 0.
+    assert visit(AbsNode(p - param("q")), ExpressionDegreeVisitor()) == 0
 
 
 def test_max_min_degree() -> None:

--- a/tests/unittests/expressions/visitor/test_equality.py
+++ b/tests/unittests/expressions/visitor/test_equality.py
@@ -33,6 +33,8 @@ from gems.expression.expression import maximum, minimum
         var("x").expec(),
         var("x").floor(),
         var("x").ceil(),
+        var("x").abs(),
+        var("x").round(),
         maximum(var("x"), param("p")),
         minimum(var("x"), param("p")),
     ],
@@ -61,6 +63,12 @@ def test_equals(expr: ExpressionNode) -> None:
         (var("x").floor(), var("y").floor()),
         (var("x").ceil(), var("y").ceil()),
         (var("x").floor(), var("x").ceil()),  # different node type
+        # abs / round
+        (var("x").abs(), var("y").abs()),
+        (var("x").round(), var("y").round()),
+        (var("x").abs(), var("x").round()),  # different node type
+        (var("x").abs(), var("x").floor()),  # different node type
+        (var("x").round(), var("x").ceil()),  # different node type
         # max / min
         (maximum(var("x"), param("p")), maximum(var("y"), param("p"))),
         (minimum(var("x"), param("p")), minimum(var("x"), param("q"))),

--- a/tests/unittests/expressions/visitor/test_evaluation.py
+++ b/tests/unittests/expressions/visitor/test_evaluation.py
@@ -88,3 +88,18 @@ def test_floor_ceil_max_min() -> None:
     assert visit(
         minimum(param("p"), param("q"), literal(5.0)), EvaluationVisitor(context)
     ) == pytest.approx(1.3)
+
+
+def test_abs_round() -> None:
+    context = EvaluationContext(parameters={"p": -2.7, "q": 1.5, "r": 2.5, "s": 3.5})
+
+    assert visit(param("p").abs(), EvaluationVisitor(context)) == pytest.approx(2.7)
+    assert visit((-param("q")).abs(), EvaluationVisitor(context)) == pytest.approx(1.5)
+    assert visit(literal(0).abs(), EvaluationVisitor(context)) == 0.0
+
+    # Banker's rounding (round-half-to-even): 0.5 -> 0, 1.5 -> 2, 2.5 -> 2, 3.5 -> 4.
+    assert visit(param("q").round(), EvaluationVisitor(context)) == 2.0
+    assert visit(param("r").round(), EvaluationVisitor(context)) == 2.0
+    assert visit(param("s").round(), EvaluationVisitor(context)) == 4.0
+    assert visit(literal(0.5).round(), EvaluationVisitor(context)) == 0.0
+    assert visit(param("p").round(), EvaluationVisitor(context)) == -3.0

--- a/tests/unittests/expressions/visitor/test_printer.py
+++ b/tests/unittests/expressions/visitor/test_printer.py
@@ -39,3 +39,13 @@ def test_floor_ceil_max_min_printer() -> None:
     # variadic (3+ operands)
     assert visit(maximum(p, q, param("r")), PrinterVisitor()) == "max(p, q, r)"
     assert visit(minimum(p, q, param("r")), PrinterVisitor()) == "min(p, q, r)"
+
+
+def test_abs_round_printer() -> None:
+    p = param("p")
+    q = param("q")
+
+    assert visit(p.abs(), PrinterVisitor()) == "abs(p)"
+    assert visit(p.round(), PrinterVisitor()) == "round(p)"
+    assert visit((p - q).abs(), PrinterVisitor()) == "abs((p - q))"
+    assert visit((p / q).round(), PrinterVisitor()) == "round((p / q))"

--- a/tests/unittests/simulation/test_simulation_table_extra_outputs.py
+++ b/tests/unittests/simulation/test_simulation_table_extra_outputs.py
@@ -155,9 +155,7 @@ def test_extra_output_abs_round_on_variable() -> None:
 
     df = SimulationTableBuilder().build(problem)
     abs_shift = (
-        df.component("comp_1")
-        .output("abs_shift")
-        .value(time_index=0, scenario_index=0)
+        df.component("comp_1").output("abs_shift").value(time_index=0, scenario_index=0)
     )
     rounded = (
         df.component("comp_1").output("rounded").value(time_index=0, scenario_index=0)

--- a/tests/unittests/simulation/test_simulation_table_extra_outputs.py
+++ b/tests/unittests/simulation/test_simulation_table_extra_outputs.py
@@ -116,3 +116,51 @@ def test_extra_output_nonlinear() -> None:
         df.component("comp_1").output("squared").value(time_index=0, scenario_index=0)
     )
     assert squared == pytest.approx(9.0)
+
+
+def test_extra_output_abs_round_on_variable() -> None:
+    """
+    abs() and round() applied to a decision variable are allowed in extra
+    outputs (post-solve evaluation), even though they would be rejected as
+    nonlinear inside a constraint or bound.
+    """
+    from gems.expression import var
+    from gems.expression.expression import literal
+    from gems.model.model import model
+    from gems.model.variable import float_variable
+    from gems.simulation import TimeBlock, build_problem
+    from gems.study import DataBase, Study, System, create_component
+
+    SIMPLE_MODEL = model(
+        id="SIMPLE_ABS_ROUND",
+        variables=[
+            float_variable("a", lower_bound=literal(2.7), upper_bound=literal(2.7))
+        ],
+        extra_outputs={
+            "abs_shift": (var("a") - literal(5)).abs(),
+            "rounded": var("a").round(),
+        },
+    )
+
+    database = DataBase()
+    comp = create_component(model=SIMPLE_MODEL, id="comp_1")
+
+    system = System("test_abs_round_extra")
+    system.add_component(comp)
+
+    problem = build_problem(
+        Study(system, database), TimeBlock(1, [0]), scenario_ids=list(range(1))
+    )
+    problem.solve(solver_name="highs")
+
+    df = SimulationTableBuilder().build(problem)
+    abs_shift = (
+        df.component("comp_1")
+        .output("abs_shift")
+        .value(time_index=0, scenario_index=0)
+    )
+    rounded = (
+        df.component("comp_1").output("rounded").value(time_index=0, scenario_index=0)
+    )
+    assert abs_shift == pytest.approx(2.3)
+    assert rounded == pytest.approx(3.0)

--- a/tests/unittests/simulation/test_vectorized_linear_expr_builder.py
+++ b/tests/unittests/simulation/test_vectorized_linear_expr_builder.py
@@ -362,7 +362,7 @@ def test_comparison_equal_also_raises(builder: VectorizedLinearExprBuilder) -> N
 
 
 # ---------------------------------------------------------------------------
-# 9. floor() / ceil() — linopy guard
+# 9. floor() / ceil() / abs() / round() — linopy guard
 # ---------------------------------------------------------------------------
 
 

--- a/tests/unittests/simulation/test_vectorized_linear_expr_builder.py
+++ b/tests/unittests/simulation/test_vectorized_linear_expr_builder.py
@@ -398,6 +398,34 @@ def test_ceil_on_exact_integer_da(builder: VectorizedLinearExprBuilder) -> None:
     assert float(result) == pytest.approx(3.0)
 
 
+def test_abs_on_da_works(builder: VectorizedLinearExprBuilder) -> None:
+    result = visit(literal(-2.5).abs(), builder)
+    assert isinstance(result, xr.DataArray)
+    assert float(result) == pytest.approx(2.5)
+
+
+def test_abs_on_variable_raises(builder: VectorizedLinearExprBuilder) -> None:
+    with pytest.raises(NotImplementedError, match="abs"):
+        visit(var("x").abs(), builder)
+
+
+def test_round_on_da_works(builder: VectorizedLinearExprBuilder) -> None:
+    result = visit(literal(2.7).round(), builder)
+    assert isinstance(result, xr.DataArray)
+    assert float(result) == pytest.approx(3.0)
+
+
+def test_round_on_variable_raises(builder: VectorizedLinearExprBuilder) -> None:
+    with pytest.raises(NotImplementedError, match="round"):
+        visit(var("x").round(), builder)
+
+
+def test_round_banker_on_da(builder: VectorizedLinearExprBuilder) -> None:
+    # Banker's rounding: 2.5 -> 2, 3.5 -> 4.
+    assert float(visit(literal(2.5).round(), builder)) == pytest.approx(2.0)
+    assert float(visit(literal(3.5).round(), builder)) == pytest.approx(4.0)
+
+
 # ---------------------------------------------------------------------------
 # 10. maximum() / minimum() — linopy guard
 # ---------------------------------------------------------------------------

--- a/tests/unittests/system/test_model.py
+++ b/tests/unittests/system/test_model.py
@@ -370,3 +370,19 @@ def test_variable_eq_with_non_variable_returns_false() -> None:
     assert v != "x"
     assert v != 42
     assert v != None  # noqa: E711
+
+
+def test_variable_bounds_accept_abs_round_of_parameters() -> None:
+    """abs/round of a parameter expression is constant, so usable in bounds."""
+    v = float_variable("x", lower_bound=-param("p").abs(), upper_bound=param("p").abs())
+    assert v.lower_bound is not None and v.upper_bound is not None
+    v2 = float_variable("x", upper_bound=(param("p") / param("q")).round())
+    assert v2.upper_bound is not None
+
+
+def test_variable_bounds_reject_abs_of_variable() -> None:
+    """abs of a variable is not constant; the bound check must reject it."""
+    with pytest.raises(ValueError, match="bounds of variables must be constant"):
+        float_variable("x", upper_bound=var("y").abs())
+    with pytest.raises(ValueError, match="bounds of variables must be constant"):
+        float_variable("x", lower_bound=var("y").round())


### PR DESCRIPTION
Two new unary operators that mirror the floor/ceil pattern:
- abs(x): absolute value
- round(x): banker's rounding (round-half-to-even), matching np.round and Python 3's built-in round.

Like floor/ceil, both operators have degree 0 when their argument has degree 0, so they are usable inside constraints, binding-constraints, objective contributions, and variable lower/upper bounds whenever the argument is constant (parameters and literals). Inside extra-outputs they may wrap any expression — including ones depending on decision variables — since extra-outputs are evaluated as numeric xr.DataArrays post-solve.

Implementation: new AbsNode/RoundNode AST nodes, .abs()/.round() factory methods, abstract methods on ExpressionVisitor with dispatch, implementations across evaluate/print/copy/equality/degree/indexing, the vectorized builder base (extra-outputs path) and its linearize guard (constraints path), and the port-field-definition checker. Parser registers abs/round in _UNARY_FUNCTIONS; no grammar change.


Closes #216 