### PR TITLE
Prepare develop/ for release v0.1.2

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to GemsPy are documented here.
 
 ---
 
-## [0.1.2] - 2026-06-09
+## [0.1.2] - 2026-06-11
 
 ### Added
 - Math operators `abs` and `round` in the GemsPy expression language.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,11 +4,18 @@ All notable changes to GemsPy are documented here.
 
 ## [Unreleased]
 
+---
+
+## [0.1.2] - 2026-06-09
+
 ### Added
 - Math operators `abs` and `round` in the GemsPy expression language.
   - Can be applied to parameters and literals in constraints, bounds, and objective contributions (degree-0 context).
   - Can be applied to any expression in extra-outputs (post-solve evaluation), including decision variables.
   - Use `.abs()` and `.round()` methods on expression objects, or `abs(expr)` and `round(expr)` in parsed expression strings.
+
+### Changed
+- Modernized README design: new layout, GEMS favicon, quick-link navigation, and `uv` install instructions.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gemspy"
-version = "0.1.1"
+version = "0.1.2"
 description = "Python interpreter for GEMS: modelling and simulation of complex energy systems under uncertainty"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -678,7 +678,7 @@ wheels = [
 
 [[package]]
 name = "gemspy"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "antlr4-python3-runtime" },


### PR DESCRIPTION
## Summary
- Bump version from `0.1.1` → `0.1.2` in `pyproject.toml` and `uv.lock`.
- Move the `Unreleased` content in `docs/CHANGELOG.md` under a new `[0.1.2] - 2026-06-09` section.
- Document the two changes that landed on `develop` since `0.1.1`:
  - **Added**: `abs` and `round` math operators in the GemsPy expression language (#217).
  - **Changed**: modernized README design (#223).

## Version-bearing files reviewed
- `pyproject.toml` — bumped.
- `uv.lock` — bumped (only the `gemspy` package entry references the project version).
- `docs/CHANGELOG.md` — finalized `[0.1.2]` section, kept an empty `[Unreleased]` for future work.
- `README.md` — only references PyPI/Python-version *badges* (no hardcoded version string), no change needed.
- `.github/workflows/publish.yml` — publishes on GitHub release events, no hardcoded version.
- `docs/` (other pages) — no hardcoded version strings outside `CHANGELOG.md`.

## Test plan
- [ ] CI green on this branch.
- [ ] After merge, cut a GitHub release tagged `v0.1.2` to trigger the PyPI publish workflow.

https://claude.ai/code/session_01AfUVdznMY9SayUVt5f3K4T

---
_Generated by [Claude Code](https://claude.ai/code/session_01AfUVdznMY9SayUVt5f3K4T)_