### PR TITLE
fix(taxonomy): import ConstraintSchema and PortFieldDefinitionSchema

### DIFF
--- a/src/gems/model/taxonomy.py
+++ b/src/gems/model/taxonomy.py
@@ -17,7 +17,11 @@ from typing import Dict, List, Optional
 import yaml
 from pydantic import Field
 
-from gems.model.parsing import LibrarySchema
+from gems.model.parsing import (
+    ConstraintSchema,
+    LibrarySchema,
+    PortFieldDefinitionSchema,
+)
 from gems.utils import ModifiedBaseModel
 
 


### PR DESCRIPTION
Fixes mypy [name-defined] errors on TaxonomyCategory fields.

## Process ID

<!-- Which governance process does this PR fall under? -->
<!-- GP-01 | GP-02 | N/A -->

**Process:**

## Description

<!-- What does this PR change and why? -->

## Impact Analysis

<!-- Which modules are affected (expression/, simulation/, study/, optim_config/)? -->
<!-- Are solver output values expected to change? If yes, document why. -->

## Checklist

- [ ] Unit tests pass (`pytest`)
- [ ] Type checking passes (`mypy`)
- [ ] Formatting passes (`black`, `isort`)
- [ ] `pyproject.toml` version bumped if applicable
- [ ] `AGENTS.md` reviewed for impact and updated if needed
