### PR TITLE
test: move model-property library tests to lib_parsing

### DIFF
--- a/tests/unittests/lib_parsing/test_lib_parsing.py
+++ b/tests/unittests/lib_parsing/test_lib_parsing.py
@@ -153,6 +153,27 @@ library:
     assert input_lib.models[0].taxonomy_category == "balance"
 
 
+_LIB_WITH_MODEL_PROPERTIES = """\
+library:
+  id: basic
+  models:
+    - id: generator
+      properties:
+        - id: technology
+"""
+
+
+def test_parse_yaml_library_model_properties() -> None:
+    lib = parse_yaml_library(io.StringIO(_LIB_WITH_MODEL_PROPERTIES))
+    assert [p.id for p in lib.models[0].properties] == ["technology"]
+
+
+def test_resolve_library_exposes_model_properties() -> None:
+    lib = parse_yaml_library(io.StringIO(_LIB_WITH_MODEL_PROPERTIES))
+    lib_dict = resolve_library([lib])
+    assert lib_dict["basic"].models["basic.generator"].properties == ["technology"]
+
+
 def test_library_error_parsing(libs_dir: Path) -> None:
     lib_file = libs_dir / "model_port_definition_ko.yml"
 

--- a/tests/unittests/system_parsing/test_components_parsing.py
+++ b/tests/unittests/system_parsing/test_components_parsing.py
@@ -205,17 +205,6 @@ library:
 """
 
 
-def test_parse_yaml_library_model_properties() -> None:
-    lib = parse_yaml_library(io.StringIO(_LIB_WITH_MODEL_PROPERTIES))
-    assert [p.id for p in lib.models[0].properties] == ["technology"]
-
-
-def test_resolve_library_exposes_model_properties() -> None:
-    lib = parse_yaml_library(io.StringIO(_LIB_WITH_MODEL_PROPERTIES))
-    lib_dict = resolve_library([lib])
-    assert lib_dict["basic"].models["basic.generator"].properties == ["technology"]
-
-
 def test_resolve_component_with_declared_property_ok() -> None:
     lib = parse_yaml_library(io.StringIO(_LIB_WITH_MODEL_PROPERTIES))
     system = parse_yaml_components(io.StringIO("""\


### PR DESCRIPTION
The tests asserting that a library exposes model-declared properties (parse + resolve) only exercise library parsing/resolution and do not involve system/component resolution, so they belong in the lib_parsing test file rather than test_components_parsing.py.

https://claude.ai/code/session_01WHJGvu1teHXBRnsTmweYtf

## Process ID

<!-- Which governance process does this PR fall under? -->
<!-- GP-01 | GP-02 | N/A -->

**Process:**

## Description

<!-- What does this PR change and why? -->

## Impact Analysis

<!-- Which modules are affected (expression/, simulation/, study/, optim_config/)? -->
<!-- Are solver output values expected to change? If yes, document why. -->

## Checklist

- [ ] Unit tests pass (`pytest`)
- [ ] Type checking passes (`mypy`)
- [ ] Formatting passes (`black`, `isort`)
- [ ] `pyproject.toml` version bumped if applicable
- [ ] `AGENTS.md` reviewed for impact and updated if needed
