### PR TITLE
(docs): Add GEMS Developer Guidelines reference to AGENTS.md and GemsPy Developer Guide [GP-02]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,3 +106,5 @@ An optional `optim-config.yml` activates decomposition: variables and constraint
 - [docs/user-guide.md](docs/user-guide.md) — Full user documentation
 - [docs/developer-guide.md](docs/developer-guide.md) — Contributor guide
 - [grammar/](grammar/) — ANTLR4 grammar source (`Expr.g4`)
+
+> **Full ecosystem developer guide:** the authoritative branching, versioning, CI/CD, and release process for all repositories (including GemsPy) lives in the GEMS Developer Guidelines, published at <https://gems-energy.readthedocs.io/en/latest/support/dev-guidelines/>. Fetch this page (e.g. via WebFetch) before any branching, versioning, or release work.

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -1,8 +1,6 @@
 # Developer guide
 
-This page aims at providing useful information for contributors.
-
-This page covers GemsPy-specific local development tasks only. The authoritative branching, versioning, CI/CD, and release process shared across all GEMS repositories (including GemsPy) lives in the **[GEMS Developer Guidelines](https://gems-energy.readthedocs.io/en/latest/support/dev-guidelines/)** — read it before any branching, versioning, or release work.
+This page provides useful information for contributors on GemsPy-specific local development tasks. The authoritative branching, versioning, CI/CD, and release process shared across all GEMS repositories (including GemsPy) lives in the **[GEMS Developer Guidelines](https://gems-energy.readthedocs.io/en/latest/support/dev-guidelines/)** — read it before any branching, versioning, or release work.
 
 ## Install dev requirements
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -2,6 +2,9 @@
 
 This page aims at providing useful information for contributors.
 
+!!! info "Ecosystem developer guidelines"
+    This page covers GemsPy-specific local development tasks only. The authoritative branching, versioning, CI/CD, and release process shared across all GEMS repositories (including GemsPy) lives in the **GEMS Developer Guidelines**: <https://gems-energy.readthedocs.io/en/latest/support/dev-guidelines/>. Read it before any branching, versioning, or release work.
+
 ## Install dev requirements
 
 Install dev requirements with `uv sync` (or `pip install -e ".[dev]"` for pip users)

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -2,8 +2,7 @@
 
 This page aims at providing useful information for contributors.
 
-!!! info "Ecosystem developer guidelines"
-    This page covers GemsPy-specific local development tasks only. The authoritative branching, versioning, CI/CD, and release process shared across all GEMS repositories (including GemsPy) lives in the **GEMS Developer Guidelines**: <https://gems-energy.readthedocs.io/en/latest/support/dev-guidelines/>. Read it before any branching, versioning, or release work.
+This page covers GemsPy-specific local development tasks only. The authoritative branching, versioning, CI/CD, and release process shared across all GEMS repositories (including GemsPy) lives in the **[GEMS Developer Guidelines](https://gems-energy.readthedocs.io/en/latest/support/dev-guidelines/)** — read it before any branching, versioning, or release work.
 
 ## Install dev requirements
 


### PR DESCRIPTION
## Description [GP-02](https://github.com/AntaresSimulatorTeam/GemsPy/issues/241)

Link the authoritative branching/versioning/CI/release guide (https://gems-energy.readthedocs.io/en/latest/support/dev-guidelines/) in the Further Reading section so agents can WebFetch it before release work. Mirrors the reference added to the converters.

