### PR TITLE
fix: filter solution/dual arrays to own model components in extra outputs

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to GemsPy are documented here.
 - Comparison operators (`>=`, `<=`, `=`) in extra-output expressions no longer raise
   `NotImplementedError` at post-solve evaluation; they now evaluate to a 0/1 indicator
   (e.g. `dual(balance) >= unsupplied_cost - 5`).
+- Extra-output `minimum()`/`maximum()` no longer break when several models coexist
+  in the same problem: solution and constraint-dual arrays are now filtered back
+  down to each model's own components before evaluation, instead of keeping the
+  NaN-padded entries introduced by linopy's outer join across models.
 
 ---
 

--- a/src/gems/simulation/simulation_table.py
+++ b/src/gems/simulation/simulation_table.py
@@ -271,7 +271,11 @@ class SimulationTableBuilder:
         if solution is not None:
             for (mk, vname), lv in problem._linopy_vars.items():
                 if lv.name in solution:
-                    var_solution_arrays[(mk, vname)] = solution[lv.name]
+                    sol_da = solution[lv.name]
+                    if "component" in sol_da.dims:
+                        own_components = list(lv.coords["component"].values)
+                        sol_da = sol_da.sel(component=own_components)
+                    var_solution_arrays[(mk, vname)] = sol_da
 
         constraint_dual_arrays = self._collect_constraint_duals(problem)
         var_reduced_cost_arrays = self._collect_reduced_costs(problem)
@@ -339,9 +343,10 @@ class SimulationTableBuilder:
         """Return constraint shadow prices keyed by (model_key, constraint_name)."""
         dual_dataset = problem.linopy_model.dual
         result: Dict[Tuple[str, str], xr.DataArray] = {}
-        for mk in problem.study.model_components:
+        for mk, components in problem.study.model_components.items():
             model = problem.study.models[mk]
             prefix = mk.replace("-", "_")
+            own_components = [c.id for c in components]
             all_constraints = {**model.constraints, **model.binding_constraints}
             for cname in all_constraints:
                 safe = cname.replace(" ", "_").replace("-", "_")
@@ -355,6 +360,8 @@ class SimulationTableBuilder:
                     dual_val = dual_val + dual_dataset[lb_name]  # type: ignore[operator]
                 if ub_name in dual_dataset:
                     dual_val = dual_val + dual_dataset[ub_name]  # type: ignore[operator]
+                if "component" in dual_val.dims:
+                    dual_val = dual_val.sel(component=own_components)
                 result[(mk, cname)] = dual_val
         return result
 

--- a/tests/unittests/simulation/test_simulation_table_extra_outputs.py
+++ b/tests/unittests/simulation/test_simulation_table_extra_outputs.py
@@ -168,6 +168,15 @@ def test_extra_output_min_on_variable() -> None:
     """
     min(variable, parameter) is allowed in extra outputs and evaluated
     element-wise post-solve.
+
+    The system also holds a second, unrelated model/component (OTHER_MODEL /
+    comp_2) alongside SIMPLE_MIN / comp_1. When multiple models coexist,
+    linopy's merged solution Dataset outer-joins their component coordinates,
+    padding each model's own variable arrays with NaN entries for the other
+    model's components. minimum()/maximum() (implemented via xr.where) are
+    sensitive to that misalignment, so this setup guards against a regression
+    where solution/dual arrays handed to VectorizedExtraOutputBuilder aren't
+    filtered back down to each model's own components.
     """
     from gems.expression import param, var
     from gems.expression.expression import literal, minimum
@@ -188,8 +197,17 @@ def test_extra_output_min_on_variable() -> None:
     comp = create_component(model=SIMPLE_MODEL, id="comp_1")
     database.add_data("comp_1", "cap", ConstantData(3.0))
 
+    OTHER_MODEL = model(
+        id="OTHER_MODEL",
+        parameters=[float_parameter("p")],
+        variables=[float_variable("b", lower_bound=literal(1), upper_bound=literal(1))],
+    )
+    other_comp = create_component(model=OTHER_MODEL, id="comp_2")
+    database.add_data("comp_2", "p", ConstantData(0.0))
+
     system = System("test_min_extra")
     system.add_component(comp)
+    system.add_component(other_comp)
 
     problem = build_problem(
         Study(system, database), TimeBlock(1, [0]), scenario_ids=list(range(1))

--- a/tests/unittests/simulation/test_simulation_table_extra_outputs.py
+++ b/tests/unittests/simulation/test_simulation_table_extra_outputs.py
@@ -168,15 +168,6 @@ def test_extra_output_min_on_variable() -> None:
     """
     min(variable, parameter) is allowed in extra outputs and evaluated
     element-wise post-solve.
-
-    The system also holds a second, unrelated model/component (OTHER_MODEL /
-    comp_2) alongside SIMPLE_MIN / comp_1. When multiple models coexist,
-    linopy's merged solution Dataset outer-joins their component coordinates,
-    padding each model's own variable arrays with NaN entries for the other
-    model's components. minimum()/maximum() (implemented via xr.where) are
-    sensitive to that misalignment, so this setup guards against a regression
-    where solution/dual arrays handed to VectorizedExtraOutputBuilder aren't
-    filtered back down to each model's own components.
     """
     from gems.expression import param, var
     from gems.expression.expression import literal, minimum


### PR DESCRIPTION
## Process ID

[GP-02] Fix `minimum()`/`maximum()` in extra outputs when multiple models coexist

**Process:** Follow-up to #240 / #237, addressing [Juliette Gerbaux's review](https://github.com/AntaresSimulatorTeam/GemsPy/pull/240#pullrequestreview-4593511884)

## Description

PR #240 added support for comparisons and `minimum()`/`maximum()` in post-solve
extra-output expressions. Juliette flagged a bug during review: when multiple
models coexist in the same problem, linopy's merged `solution`/`dual` Datasets
outer-join their `component` coordinates, so a model's own variable/dual arrays
get padded with NaN entries for *other* models' components. `minimum()`/`maximum()`
(implemented via `xr.where`, which requires exact coordinate alignment) then
raise an `AlignmentError` instead of evaluating.

This PR filters `var_solution_arrays` and `constraint_dual_arrays` back down to
each model's own components in `simulation_table.py::_collect_extra_outputs` /
`_collect_constraint_duals`, mirroring the guard already present in the sibling
method `_collect_vars_outputs`. `test_extra_output_min_on_variable` is extended
with a second, unrelated model/component (`OTHER_MODEL` / `comp_2`) to reproduce
the outer-join scenario and guard against regressions, per Juliette's inline
suggestions on #240.

Verified the new test fails with `xarray.structure.alignment.AlignmentError`
before this fix and passes after.

## Impact Analysis

`simulation/simulation_table.py` — only affects extra-output evaluation when a
study has multiple models with disjoint component sets; solver output values
for existing single-model tests are unchanged.

## Checklist

- [x] Unit tests pass (`pytest`)
- [x] Type checking passes (`mypy`)
- [x] Formatting passes (`black`, `isort`)
- [ ] `pyproject.toml` version bumped if applicable
- [x] `AGENTS.md` reviewed for impact and updated if needed


---
_Generated by [Claude Code](https://claude.ai/code/session_01WhBSqeumt6WEjH5mrM18o6)_