### PR TITLE
fix(deps): revert runner extra, restore full deps in pip install gemspy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           enable-cache: true
 
       - name: Install dependencies
-        run: uv sync --group dev --group solvers --extra runner
+        run: uv sync --group dev --group solvers
 
       - name: Check imports sort order
         run: uv run isort --profile black --check-only --diff src tests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,9 +63,9 @@ An optional `optim-config.yml` activates decomposition: variables and constraint
 
 The codebase is split into three packages along a solver-dependency boundary:
 
-- **`gems_craft`** (`src/gems_craft/`) — the domain model and all YAML I/O. No solver dependency; installable and usable on its own (`pip install gemspy`, without the `runner` extra) for building, editing, validating, and querying systems (e.g. an API layer). Deps: `numpy`, `pandas`, `PyYAML`, `pydantic`, `anytree`, `antlr4-python3-runtime`.
+- **`gems_craft`** (`src/gems_craft/`) — the domain model and all YAML I/O. No solver dependency at the module level; importable on its own for building, editing, validating, and querying systems (e.g. an API layer) without touching solve-time code. Deps: `numpy`, `pandas`, `PyYAML`, `pydantic`, `anytree`, `antlr4-python3-runtime`.
 - **`gems_craft_hybrid`** (`src/gems_craft_hybrid/`) — read/write support for *hybrid* GEMS studies, an extended format used to interoperate with Antares Simulator. No solver dependency; depends only on `gems_craft`. Hybrid studies cannot be simulated by GemsPy — this package only extends the `gems_craft` parsing schemas (`HybridLibrarySchema`, `HybridSystemSchema`) with the extra fields (`area-connection`, `thermal-capacity-connection` on port-types; `area-connections`, `thermal-capacity-connections` on systems), reusing `gems_craft`'s schema-parameterized `parse_yaml_library`/`load_input_system`/`parse_yaml_system`/`write_yaml_library`/`write_yaml_system`.
-- **`gems_runner`** (`src/gems_runner/`) — solve-time execution. Depends on `gems_craft` plus the `runner` extra (`linopy`, `xarray`, `highspy`).
+- **`gems_runner`** (`src/gems_runner/`) — solve-time execution. Depends on `gems_craft` plus `linopy`, `xarray`, `highspy`, all installed as part of the base `gemspy` package (`pip install gemspy` installs the full solver stack, not just `gems_craft`'s dependencies).
 
 ### Core Modules
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -36,12 +36,16 @@ All notable changes to GemsPy are documented here.
     `pydantic`, `anytree`, `antlr4-python3-runtime` - no solver required.
   - `gems_runner` holds solve-time execution: `expression.evaluate`,
     `session`, `simulation`, `study.runner`, `main` (the `gemspy` CLI). It
-    depends on `gems_craft` plus the new `runner` extra (`linopy`, `xarray`,
-    `highspy`).
+    depends on `gems_craft` plus `linopy`, `xarray`, `highspy`.
   - All `gems.*` imports must be updated to `gems_craft.*` or `gems_runner.*`
     accordingly; see the module lists above. The `gemspy` console script now
     points at `gems_runner.main.main:main_cli`.
-    
+- **Revert of the `runner` extra** - `linopy`, `xarray`, and `highspy` are
+  back in `gemspy`'s base dependencies instead of an optional `runner` extra.
+  `pip install gemspy` now installs the full solver stack again, as it did
+  before the package split above. The `gems_craft`/`gems_runner`/
+  `gems_craft_hybrid` module split is unaffected.
+
 ### Fixed
 - Comparison operators (`>=`, `<=`, `=`) in extra-output expressions no longer raise
   `NotImplementedError` at post-solve evaluation; they now evaluate to a 0/1 indicator

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -40,11 +40,6 @@ All notable changes to GemsPy are documented here.
   - All `gems.*` imports must be updated to `gems_craft.*` or `gems_runner.*`
     accordingly; see the module lists above. The `gemspy` console script now
     points at `gems_runner.main.main:main_cli`.
-- **Revert of the `runner` extra** - `linopy`, `xarray`, and `highspy` are
-  back in `gemspy`'s base dependencies instead of an optional `runner` extra.
-  `pip install gemspy` now installs the full solver stack again, as it did
-  before the package split above. The `gems_craft`/`gems_runner`/
-  `gems_craft_hybrid` module split is unaffected.
 
 ### Fixed
 - Comparison operators (`>=`, `<=`, `=`) in extra-output expressions no longer raise

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,9 @@ dependencies = [
     "PyYAML>=6.0.2",
     "pydantic>=2.0",
     "anytree>=2.13",
+    "linopy>=0.6",
+    "xarray>=2025.3",
+    "highspy>=1.14",
     "pandas>=2.2",
     "attrs>=26.0",
 ]
@@ -54,11 +57,6 @@ doc = [
     "mkdocs-material",
     "mkdocs-material-extensions",
     "mkdocstrings-python",
-]
-runner = [
-    "linopy>=0.6",
-    "xarray>=2025.3",
-    "highspy>=1.14",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -684,12 +684,16 @@ dependencies = [
     { name = "antlr4-python3-runtime" },
     { name = "anytree" },
     { name = "attrs" },
+    { name = "highspy" },
+    { name = "linopy" },
     { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "pandas", version = "3.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pydantic" },
     { name = "pyyaml" },
+    { name = "xarray", version = "2025.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "xarray", version = "2026.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 
 [package.optional-dependencies]
@@ -698,12 +702,6 @@ doc = [
     { name = "mkdocs-material" },
     { name = "mkdocs-material-extensions" },
     { name = "mkdocstrings-python" },
-]
-runner = [
-    { name = "highspy" },
-    { name = "linopy" },
-    { name = "xarray", version = "2025.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "xarray", version = "2026.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 
 [package.dev-dependencies]
@@ -730,8 +728,8 @@ requires-dist = [
     { name = "antlr4-python3-runtime", specifier = ">=4.13.2" },
     { name = "anytree", specifier = ">=2.13" },
     { name = "attrs", specifier = ">=26.0" },
-    { name = "highspy", marker = "extra == 'runner'", specifier = ">=1.14" },
-    { name = "linopy", marker = "extra == 'runner'", specifier = ">=0.6" },
+    { name = "highspy", specifier = ">=1.14" },
+    { name = "linopy", specifier = ">=0.6" },
     { name = "mkdocs", marker = "extra == 'doc'" },
     { name = "mkdocs-material", marker = "extra == 'doc'" },
     { name = "mkdocs-material-extensions", marker = "extra == 'doc'" },
@@ -740,9 +738,9 @@ requires-dist = [
     { name = "pandas", specifier = ">=2.2" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pyyaml", specifier = ">=6.0.2" },
-    { name = "xarray", marker = "extra == 'runner'", specifier = ">=2025.3" },
+    { name = "xarray", specifier = ">=2025.3" },
 ]
-provides-extras = ["doc", "runner"]
+provides-extras = ["doc"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
PR #244 split gems into gems_craft/gems_runner and moved linopy, xarray,
and highspy into an optional "runner" extra so pip install gemspy would
only pull gems_craft's dependencies. Issue #252 asks to revert only that
dependency-scoping decision, not the module split: pip install gemspy
should install the full solver stack again.

- pyproject.toml: move linopy/xarray/highspy back into base dependencies,
  drop the now-empty runner extra
- uv.lock: regenerated via uv lock
- ci.yml: drop --extra runner from the uv sync install step
- AGENTS.md, CHANGELOG.md: update docs to match

Closes #252