### PR TITLE
release: v0.1.3

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to GemsPy are documented here.
 
 ## [Unreleased]
 
+## [0.1.3] - 2026-07-24
+
 ### Added
 - **`taxonomy` field on `LibrarySchema`** - optional free-form string field on
   the library YAML schema; no validation is attached. `taxonomy` is also

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gemspy"
-version = "0.1.2"
+version = "0.1.3"
 description = "Python interpreter for GEMS: modelling and simulation of complex energy systems under uncertainty"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -678,7 +678,7 @@ wheels = [
 
 [[package]]
 name = "gemspy"
-version = "0.1.2"
+version = "0.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "antlr4-python3-runtime" },


### PR DESCRIPTION
## Process ID

**Process:** N/A

## Description

Release prep for GemsPy 0.1.3, following the same pattern as the previous release (v0.1.2, #224/#225): a pure version-bump + changelog-finalization PR, no code changes.

- Bump version `0.1.2` → `0.1.3` in `pyproject.toml` and `uv.lock`.
- Finalize `docs/CHANGELOG.md`: the `[Unreleased]` section (already fully written, matching the 30 commits merged since `v0.1.2`) becomes `## [0.1.3] - 2026-07-24`, with a fresh empty `[Unreleased]` section left at the top for the next cycle.

Highlights of what's in the 0.1.3 changelog entry:
- **Package split**: the monolithic `gems` package is split into `gems_craft` (solver-independent domain model/I/O) and `gems_runner` (solve-time execution, CLI).
- **New `gems_craft_hybrid` package**: read/write GEMS studies extended with fields to interoperate with Antares Simulator.
- **`taxonomy` and `version` fields** added to `LibrarySchema`.
- **Fixes**: comparison operators in extra-outputs no longer raise `NotImplementedError`; `minimum()`/`maximum()` extra-output fix for multi-model NaN-padding.

## Impact Analysis

No functional code changes — only `pyproject.toml`, `uv.lock`, and `docs/CHANGELOG.md` are touched. No impact on modules (`expression/`, `simulation/`, `study/`, `optim_config/`) and no expected change in solver output values.

## Checklist

- [x] Unit tests pass (`pytest`) — 557 passed, 6 skipped, 1 xfailed
- [x] Type checking passes (`mypy`)
- [x] Formatting passes (`black`, `isort`)
- [x] `pyproject.toml` version bumped
- [x] `AGENTS.md` reviewed for impact and updated if needed — no changes needed for this release-prep PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01FdX4R8obFaLPgwiwmZPL5a)_