### PR TITLE
Fix/allow extra inputs in library parsing

### DIFF
--- a/src/gems_craft/model/parsing.py
+++ b/src/gems_craft/model/parsing.py
@@ -17,7 +17,10 @@ from typing import List, Optional, Type, TypeVar, overload
 from pydantic import ConfigDict, Field, ValidationError
 from yaml import safe_dump, safe_load
 
-from gems_craft.model.port_type_schemas import AreaConnectionSchema, PortThermalCapacitySchema
+from gems_craft.model.port_type_schemas import (
+    AreaConnectionSchema,
+    PortThermalCapacitySchema,
+)
 from gems_craft.utils import ModifiedBaseModel
 
 

--- a/src/gems_craft/model/parsing.py
+++ b/src/gems_craft/model/parsing.py
@@ -17,6 +17,7 @@ from typing import List, Optional, Type, TypeVar, overload
 from pydantic import ConfigDict, Field, ValidationError
 from yaml import safe_dump, safe_load
 
+from gems_craft.model.port_type_schemas import AreaConnectionSchema, PortThermalCapacitySchema
 from gems_craft.utils import ModifiedBaseModel
 
 
@@ -53,6 +54,8 @@ class FieldSchema(ModifiedBaseModel):
 class PortTypeSchema(ModifiedBaseModel):
     id: str
     fields: List[FieldSchema] = Field(default_factory=list)
+    area_connection: Optional[AreaConnectionSchema] = None
+    thermal_capacity_connection: Optional[PortThermalCapacitySchema] = None
     description: Optional[str] = None
 
 

--- a/src/gems_craft/model/port_type_schemas.py
+++ b/src/gems_craft/model/port_type_schemas.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2024, RTE (https://www.rte-france.com)
+#
+# See AUTHORS.txt
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# SPDX-License-Identifier: MPL-2.0
+#
+# This file is part of the Antares project.
+
+from typing import Optional
+
+from gems_craft.utils import ModifiedBaseModel
+
+
+class AreaConnectionSchema(ModifiedBaseModel):
+    injection_to_balance: Optional[str] = None
+    spillage_bound: Optional[str] = None
+    unsupplied_energy_bound: Optional[str] = None
+
+
+class PortThermalCapacitySchema(ModifiedBaseModel):
+    capacity_field: str

--- a/src/gems_craft_hybrid/model/parsing.py
+++ b/src/gems_craft_hybrid/model/parsing.py
@@ -15,7 +15,10 @@ from typing import List, Optional, TextIO
 from pydantic import Field
 
 from gems_craft.model.parsing import LibrarySchema, PortTypeSchema, parse_yaml_library
-from gems_craft.model.port_type_schemas import AreaConnectionSchema, PortThermalCapacitySchema
+from gems_craft.model.port_type_schemas import (
+    AreaConnectionSchema,
+    PortThermalCapacitySchema,
+)
 
 
 class HybridPortTypeSchema(PortTypeSchema):

--- a/src/gems_craft_hybrid/model/parsing.py
+++ b/src/gems_craft_hybrid/model/parsing.py
@@ -15,17 +15,7 @@ from typing import List, Optional, TextIO
 from pydantic import Field
 
 from gems_craft.model.parsing import LibrarySchema, PortTypeSchema, parse_yaml_library
-from gems_craft.utils import ModifiedBaseModel
-
-
-class AreaConnectionSchema(ModifiedBaseModel):
-    injection_to_balance: Optional[str] = None
-    spillage_bound: Optional[str] = None
-    unsupplied_energy_bound: Optional[str] = None
-
-
-class PortThermalCapacitySchema(ModifiedBaseModel):
-    capacity_field: str
+from gems_craft.model.port_type_schemas import AreaConnectionSchema, PortThermalCapacitySchema
 
 
 class HybridPortTypeSchema(PortTypeSchema):

--- a/tests/unittests/gems_craft_hybrid/test_hybrid_parsing.py
+++ b/tests/unittests/gems_craft_hybrid/test_hybrid_parsing.py
@@ -139,7 +139,9 @@ def test_load_standard_library_on_hybrid_file_parses_area_connection() -> None:
     )
 
 
-def test_load_standard_library_on_hybrid_file_parses_thermal_capacity_connection() -> None:
+def test_load_standard_library_on_hybrid_file_parses_thermal_capacity_connection() -> (
+    None
+):
     """parse_yaml_library (standard) and parses thermal-capacity-connection fields."""
     with FIXTURES.joinpath("hybrid_lib.yml").open() as f:
         lib = parse_yaml_library(f)

--- a/tests/unittests/gems_craft_hybrid/test_hybrid_parsing.py
+++ b/tests/unittests/gems_craft_hybrid/test_hybrid_parsing.py
@@ -13,17 +13,14 @@
 """Tests for gems_craft_hybrid parsing: HybridSystemSchema and HybridLibrarySchema."""
 
 from pathlib import Path
-from typing import Type, TypeVar
 
 import pytest
 
 from gems_craft.model.parsing import (
-    LibrarySchema,
     parse_yaml_library,
     write_yaml_library,
 )
 from gems_craft.study.parsing import (
-    SystemSchema,
     parse_yaml_system,
     write_yaml_system,
 )
@@ -130,11 +127,28 @@ def test_load_hybrid_library_port_type_without_area_connection() -> None:
     assert signal_port.area_connection is None
 
 
-def test_load_standard_library_on_hybrid_file_raises() -> None:
-    """parse_yaml_library (standard) rejects hybrid-only fields due to extra='forbid'."""
+def test_load_standard_library_on_hybrid_file_parses_area_connection() -> None:
+    """parse_yaml_library (standard) and parses area-connection fields."""
     with FIXTURES.joinpath("hybrid_lib.yml").open() as f:
-        with pytest.raises(ValueError):
-            parse_yaml_library(f)
+        lib = parse_yaml_library(f)
+    flow_port = next(pt for pt in lib.port_types if pt.id == "flow")
+    assert flow_port.area_connection == AreaConnectionSchema(
+        injection_to_balance="flow",
+        spillage_bound="flow",
+        unsupplied_energy_bound=None,
+    )
+
+
+def test_load_standard_library_on_hybrid_file_parses_thermal_capacity_connection() -> None:
+    """parse_yaml_library (standard) and parses thermal-capacity-connection fields."""
+    with FIXTURES.joinpath("hybrid_lib.yml").open() as f:
+        lib = parse_yaml_library(f)
+    capacity_port = next(
+        pt for pt in lib.port_types if pt.id == "antares_thermal_cluster_capacity"
+    )
+    assert capacity_port.thermal_capacity_connection == PortThermalCapacitySchema(
+        capacity_field="capacity"
+    )
 
 
 def test_parse_yaml_hybrid_library_reads_hybrid_fields() -> None:


### PR DESCRIPTION
## Process ID

<!-- Which governance process does this PR fall under? -->
<!-- GP-01 | GP-02 | N/A -->

**Process:**
GP-02
## Description

<!-- What does this PR change and why? -->
It solves the issue #263 

## Impact Analysis

<!-- Which modules are affected (expression/, simulation/, study/, optim_config/)? -->
<!-- Are solver output values expected to change? If yes, document why. -->

yes, as we parse now the area-connection and thermal-capacity-connection sections

## Checklist

- [x] Unit tests pass (`pytest`)
- [ ] Type checking passes (`mypy`)
- [ ] Formatting passes (`black`, `isort`)
- [ ] `pyproject.toml` version bumped if applicable
- [ ] `AGENTS.md` reviewed for impact and updated if needed
