### PR TITLE
test(carry-over): assert the pinned constraint window, not the values

### DIFF
--- a/tests/e2e/functional/test_sequential_carry_over_length.py
+++ b/tests/e2e/functional/test_sequential_carry_over_length.py
@@ -38,25 +38,17 @@ re-optimize to the same value from a fixed one.
 import shutil
 import textwrap
 from pathlib import Path
-from typing import Any, List, Optional, Set
+from typing import Any, List, Set
 
 import pandas as pd
 import pytest
-import xarray as xr
 
-from gems_craft.expression.expression import literal, param, var
-from gems_craft.model import Constraint, float_parameter, float_variable, model
 from gems_craft.optim_config.parsing import load_optim_config
-from gems_craft.study import ConstantData, DataBase, Study, System, create_component
 from gems_craft.study.folder import load_study
 from gems_runner.session.session import SimulationSession
-from gems_runner.simulation import TimeBlock, build_problem
-from gems_runner.simulation.optimization import (
-    OptimizationProblem,
-    _validate_initial_values,
-)
+from gems_runner.simulation import TimeBlock
+from gems_runner.simulation.optimization import OptimizationProblem
 from gems_runner.study.runner import run_study
-from tests.e2e.functional.libs.standard import CONSTANT
 
 _STUDY_SRC = Path(__file__).parent / "studies" / "rolling_horizon_suboptimality"
 
@@ -198,15 +190,18 @@ def _pinned_window_lengths(problem: OptimizationProblem) -> Set[int]:
     }
 
 
-@pytest.fixture(params=[None, 0, 1, 2], ids=["omitted", "0", "1", "2"])
-def carry_over_length(request: pytest.FixtureRequest) -> Optional[int]:
-    """`carry-over-length` under test: explicitly 0, 1 or 2, or omitted from
-    the config — which resolves to `block-overlap`."""
-    return request.param
-
-
+@pytest.mark.parametrize(
+    "setting, expected",
+    [
+        # Omitted resolves to `block-overlap`: the whole overlap zone is pinned.
+        ("# carry-over-length omitted", _BLOCK_OVERLAP),
+        ("carry-over-length: 0", 0),
+        ("carry-over-length: 1", 1),
+        ("carry-over-length: 2", 2),
+    ],
+)
 def test_carry_over_length_fixes_that_many_leading_timesteps(
-    tmp_path: Path, carry_over_length: Optional[int]
+    tmp_path: Path, setting: str, expected: int
 ) -> None:
     """`carry-over-length: k` fixes, in every block but the first, the k
     leading local timesteps — the k earliest shared timesteps — to the previous
@@ -215,15 +210,8 @@ def test_carry_over_length_fixes_that_many_leading_timesteps(
     `k = 0` fixes nothing at all: the blocks still overlap (so lag constraints
     keep their history) but are not stitched.
     """
-    setting = (
-        "# carry-over-length omitted"
-        if carry_over_length is None
-        else f"carry-over-length: {carry_over_length}"
-    )
-    expected = _BLOCK_OVERLAP if carry_over_length is None else carry_over_length
-
     problems = _run_sequential_session(
-        tmp_path, f"carry_over_{carry_over_length}", _sequential_config(setting)
+        tmp_path, f"carry_over_{expected}", _sequential_config(setting)
     )
     # block-length=6, block-overlap=3, t=0..11 → blocks [0..5], [3..8], [6..11]
     # and the truncated tail [9..11].
@@ -295,88 +283,3 @@ def test_zero_overlap_blocks_fully_independent(tmp_path: Path) -> None:
                 f"sequential (block-overlap: 0) and parallel modes disagree at "
                 f"t={t} for {component}.{output}: {v_seq} != {v_par}"
             )
-
-
-# ---------------------------------------------------------------------------
-# `initial_values` contract, at the `build_problem` level
-#
-# The tests above are run-level: they observe the pinned values, not the
-# constraints that produced them.  These two build a problem directly to check
-# *which* variables the carry-over pins, and that a malformed `initial_values`
-# is rejected before anything is built.
-# ---------------------------------------------------------------------------
-
-
-def _one_time_dependent_one_constant_study() -> Study:
-    """A single-component study whose model has one time-dependent variable
-    (`gen`) and one time-independent one (`cap`)."""
-    plant = model(
-        id="PLANT",
-        parameters=[float_parameter("cost", CONSTANT)],
-        variables=[
-            float_variable("gen", lower_bound=literal(0), upper_bound=literal(10)),
-            float_variable(
-                "cap",
-                lower_bound=literal(0),
-                upper_bound=literal(10),
-                structure=CONSTANT,
-            ),
-        ],
-        constraints=[
-            Constraint(name="Max generation", expression=var("gen") <= var("cap"))
-        ],
-        objective_contributions={
-            "operational": (param("cost") * var("gen")).time_sum().expec()
-        },
-    )
-    database = DataBase()
-    database.add_data("P", "cost", ConstantData(1))
-    system = System("carry_over_contract")
-    system.add_component(create_component(model=plant, id="P"))
-    return Study(system, database)
-
-
-def _time_da(values: list[float]) -> xr.DataArray:
-    """Carry-over array in the shape `_extract_carry_over` produces: a `time`
-    dimension indexed 0..k-1."""
-    return xr.DataArray(
-        values, dims=["time"], coords={"time": list(range(len(values)))}
-    )
-
-
-def test_carry_over_skips_time_independent_variables() -> None:
-    """Only time-dependent variables are pinned.  A time-independent variable
-    (`structure.time = False`) is left free in every block even when the caller
-    passes a value for it, so consecutive blocks size it independently."""
-    problem = build_problem(
-        _one_time_dependent_one_constant_study(),
-        TimeBlock(1, [0, 1, 2]),
-        [0],
-        initial_values={
-            ("PLANT", "gen"): _time_da([2.0, 3.0]),
-            ("PLANT", "cap"): _time_da([7.0]),
-        },
-    )
-
-    constraint_names = set(problem.linopy_model.constraints)
-    assert "carry_over__PLANT__gen" in constraint_names
-    assert "carry_over__PLANT__cap" not in constraint_names
-
-
-def test_initial_values_without_time_dim_rejected() -> None:
-    """A value with no `time` dimension — the shape carried over before
-    multi-timestep stitching existed — is rejected outright rather than
-    silently reinterpreted as a single-timestep pin."""
-    with pytest.raises(ValueError, match="must carry a 'time' dimension"):
-        build_problem(
-            _one_time_dependent_one_constant_study(),
-            TimeBlock(1, [0, 1, 2]),
-            [0],
-            initial_values={("PLANT", "gen"): xr.DataArray(2.0)},
-        )
-
-    # The check is a precondition on the argument, so it does not need a study:
-    with pytest.raises(ValueError, match="must carry a 'time' dimension"):
-        _validate_initial_values({("PLANT", "gen"): xr.DataArray(2.0)})
-
-    assert _validate_initial_values(None) == {}

--- a/tests/e2e/functional/test_sequential_carry_over_length.py
+++ b/tests/e2e/functional/test_sequential_carry_over_length.py
@@ -15,8 +15,7 @@ E2E test: multi-timestep carry-over in sequential mode.
 
 Reuses the rolling_horizon_suboptimality study (generator p_max=2/cost=1,
 storage capacity=2/rate=2, bus with ens_cost=100) with a longer, aperiodic
-12-step demand series so that the storage state-of-charge trajectory varies
-across block boundaries.
+12-step demand series.
 
 Sequential mode with block-length=6, block-overlap=3 over t=0..11:
 
@@ -30,14 +29,16 @@ Consecutive blocks share `block-overlap` = 3 absolute timesteps.  The
 N's already-solved values — counted from the *earliest* shared timestep, so
 each pinned constraint matches the same absolute timestep in both blocks.
 
-The tests assert, from the merged simulation table (which keeps one row per
-block for overlapping timesteps), that every pinned shared timestep carries
-identical values in both blocks' solutions.
+`carry-over-length` is checked on the carry-over constraints themselves: what
+the setting controls is which variables are *fixed* and which are left free,
+and comparing solved values cannot tell a free timestep that happens to
+re-optimize to the same value from a fixed one.
 """
 
 import shutil
 import textwrap
 from pathlib import Path
+from typing import Any, List, Optional, Set
 
 import pandas as pd
 import pytest
@@ -45,9 +46,15 @@ import xarray as xr
 
 from gems_craft.expression.expression import literal, param, var
 from gems_craft.model import Constraint, float_parameter, float_variable, model
+from gems_craft.optim_config.parsing import load_optim_config
 from gems_craft.study import ConstantData, DataBase, Study, System, create_component
+from gems_craft.study.folder import load_study
+from gems_runner.session.session import SimulationSession
 from gems_runner.simulation import TimeBlock, build_problem
-from gems_runner.simulation.optimization import _validate_initial_values
+from gems_runner.simulation.optimization import (
+    OptimizationProblem,
+    _validate_initial_values,
+)
 from gems_runner.study.runner import run_study
 from tests.e2e.functional.libs.standard import CONSTANT
 
@@ -79,12 +86,16 @@ _BASE_CONFIG = textwrap.dedent("""\
 """)
 
 
+_BLOCK_LENGTH = 6
+_BLOCK_OVERLAP = 3
+
+
 def _sequential_config(carry_over_length: str) -> str:
     return _BASE_CONFIG + textwrap.dedent(f"""\
         resolution:
           mode: sequential-subproblems
-          block-length: 6
-          block-overlap: 3
+          block-length: {_BLOCK_LENGTH}
+          block-overlap: {_BLOCK_OVERLAP}
           {carry_over_length}
     """)
 
@@ -141,62 +152,100 @@ def _shared_timesteps(raw: pd.DataFrame) -> dict:
     }
 
 
-def _assert_pinned_window_consistent(raw: pd.DataFrame, carry_over_length: int) -> None:
-    """The first `carry_over_length` shared timesteps of each consecutive block
-    pair must have identical values in both blocks, for every output."""
-    shared = _shared_timesteps(raw)
-    assert shared, "Expected at least two consecutive blocks"
-    for (block_n, block_n1), timesteps in shared.items():
-        assert timesteps, f"Blocks {block_n} and {block_n1} share no timesteps"
-        for t in timesteps[:carry_over_length]:
-            for component, output in _OUTPUTS:
-                v_prev = _get_value(raw, block_n, component, output, int(t))
-                v_next = _get_value(raw, block_n1, component, output, int(t))
-                assert v_next == pytest.approx(v_prev, abs=1e-6), (
-                    f"Pinned timestep t={t} disagrees between block {block_n} "
-                    f"({v_prev}) and block {block_n1} ({v_next}) for "
-                    f"{component}.{output}"
-                )
+def _run_sequential_session(
+    tmp_path: Path, name: str, config_yaml: str
+) -> List[OptimizationProblem]:
+    """Run the study through a `SimulationSession` and return the solved
+    problems, one per block, in solve order.
+
+    `run_study` drops them; the session hands each one back
+    (`SimulationSession._run_block` returns the solved problem for carry-over
+    extraction *or inspection*), which is what gives the test access to the
+    carry-over constraints.
+    """
+    study_dir = tmp_path / name
+    shutil.copytree(_STUDY_SRC, study_dir)
+    demand_path = study_dir / "input" / "data-series" / "demand.txt"
+    demand_path.write_text("\n".join(str(d) for d in _DEMAND_12) + "\n")
+    config_path = study_dir / "input" / "optim-config.yml"
+    config_path.write_text(config_yaml)
+
+    optim_config = load_optim_config(config_path)
+    assert optim_config is not None
+    session = SimulationSession(load_study(study_dir), optim_config)
+
+    problems: List[OptimizationProblem] = []
+    run_block = session._run_block
+
+    def spy(block: TimeBlock, **kwargs: Any) -> Any:
+        problem, table = run_block(block, **kwargs)
+        problems.append(problem)
+        return problem, table
+
+    session._run_block = spy  # type: ignore[assignment]
+    session.run()
+    return problems
 
 
-def test_full_pin_default(tmp_path: Path) -> None:
-    """Omitted carry-over-length defaults to block-overlap: the whole overlap
-    zone of every consecutive block pair is pinned to the earlier block's
-    values, timestep by absolute timestep."""
-    raw = _run(tmp_path, "full_pin", _sequential_config("# carry-over-length omitted"))
-
-    shared = _shared_timesteps(raw)
-    # block-length=6, block-overlap=3, t=0..11 → blocks [0..5], [3..8],
-    # [6..11], [9..11]; consecutive pairs share exactly 3 timesteps.
-    assert shared == {
-        (0, 1): [3, 4, 5],
-        (1, 2): [6, 7, 8],
-        (2, 3): [9, 10, 11],
+def _pinned_window_lengths(problem: OptimizationProblem) -> Set[int]:
+    """Number of timesteps each carry-over equality constraint of `problem`
+    fixes.  Empty when the block carries nothing over."""
+    linopy_model = problem.linopy_model
+    return {
+        int(linopy_model.constraints[name].sizes["time"])
+        for name in linopy_model.constraints
+        if name.startswith("carry_over__")
     }
-    _assert_pinned_window_consistent(raw, carry_over_length=3)
 
 
-def test_explicit_full_pin(tmp_path: Path) -> None:
-    """carry-over-length equal to block-overlap behaves like the default."""
-    raw = _run(tmp_path, "explicit_full", _sequential_config("carry-over-length: 3"))
-    _assert_pinned_window_consistent(raw, carry_over_length=3)
+@pytest.fixture(params=[None, 0, 1, 2], ids=["omitted", "0", "1", "2"])
+def carry_over_length(request: pytest.FixtureRequest) -> Optional[int]:
+    """`carry-over-length` under test: explicitly 0, 1 or 2, or omitted from
+    the config — which resolves to `block-overlap`."""
+    return request.param
 
 
-def test_partial_pin(tmp_path: Path) -> None:
-    """carry-over-length < block-overlap pins only the leading shared
-    timesteps; the rest of the overlap zone is re-optimized freely."""
-    raw = _run(tmp_path, "partial_pin", _sequential_config("carry-over-length: 1"))
-    _assert_pinned_window_consistent(raw, carry_over_length=1)
+def test_carry_over_length_fixes_that_many_leading_timesteps(
+    tmp_path: Path, carry_over_length: Optional[int]
+) -> None:
+    """`carry-over-length: k` fixes, in every block but the first, the k
+    leading local timesteps — the k earliest shared timesteps — to the previous
+    block's solution, and leaves the rest of the overlap zone free.
 
+    `k = 0` fixes nothing at all: the blocks still overlap (so lag constraints
+    keep their history) but are not stitched.
+    """
+    setting = (
+        "# carry-over-length omitted"
+        if carry_over_length is None
+        else f"carry-over-length: {carry_over_length}"
+    )
+    expected = _BLOCK_OVERLAP if carry_over_length is None else carry_over_length
 
-def test_zero_carry_over(tmp_path: Path) -> None:
-    """Explicit carry-over-length: 0 disables stitching entirely: every block
-    is solved independently over its own window, and every timestep of the
-    horizon is still present in the output."""
-    raw = _run(tmp_path, "zero_carry", _sequential_config("carry-over-length: 0"))
+    problems = _run_sequential_session(
+        tmp_path, f"carry_over_{carry_over_length}", _sequential_config(setting)
+    )
+    # block-length=6, block-overlap=3, t=0..11 → blocks [0..5], [3..8], [6..11]
+    # and the truncated tail [9..11].
+    assert len(problems) == 4
 
-    timesteps = set(raw["absolute_time_index"].dropna().astype(int))
-    assert timesteps == set(range(12))
+    assert not _pinned_window_lengths(
+        problems[0]
+    ), "Nothing is carried into the first block"
+
+    for block_id, problem in enumerate(problems[1:], start=1):
+        windows = _pinned_window_lengths(problem)
+        if expected == 0:
+            assert not windows, (
+                f"Block {block_id}: 'carry-over-length: 0' must leave the whole "
+                f"overlap zone free, found constraints fixing {sorted(windows)} "
+                f"timestep(s)"
+            )
+        else:
+            assert windows == {expected}, (
+                f"Block {block_id}: every carry-over constraint must fix the "
+                f"{expected} leading timesteps, found {sorted(windows)}"
+            )
 
 
 def _no_overlap_config(mode: str) -> str:

--- a/tests/unittests/gems_runner/simulation/test_carry_over_initial_values.py
+++ b/tests/unittests/gems_runner/simulation/test_carry_over_initial_values.py
@@ -1,0 +1,111 @@
+# Copyright (c) 2026, RTE (https://www.rte-france.com)
+#
+# See AUTHORS.txt
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# SPDX-License-Identifier: MPL-2.0
+#
+# This file is part of the Antares project.
+
+"""
+Tests the `initial_values` contract of `build_problem`, i.e. how a carry-over
+window from the previous block is turned into constraints of the next one:
+
+- only time-dependent variables are pinned — a time-independent variable
+  (`structure.time = False`) is left free in every block;
+- a value with no `time` dimension is rejected outright.
+
+The pinned *window length*, which `carry-over-length` controls through the
+session, is covered end to end in
+`tests/e2e/functional/test_sequential_carry_over_length.py`.
+"""
+
+import pytest
+import xarray as xr
+
+from gems_craft.expression.expression import literal, param, var
+from gems_craft.expression.indexing_structure import IndexingStructure
+from gems_craft.model import Constraint, float_parameter, float_variable, model
+from gems_craft.study import ConstantData, DataBase, Study, System, create_component
+from gems_runner.simulation import TimeBlock, build_problem
+from gems_runner.simulation.optimization import _validate_initial_values
+
+CONSTANT = IndexingStructure(False, False)
+
+
+def _one_time_dependent_one_constant_study() -> Study:
+    """A single-component study whose model has one time-dependent variable
+    (`gen`) and one time-independent one (`cap`)."""
+    plant = model(
+        id="PLANT",
+        parameters=[float_parameter("cost", CONSTANT)],
+        variables=[
+            float_variable("gen", lower_bound=literal(0), upper_bound=literal(10)),
+            float_variable(
+                "cap",
+                lower_bound=literal(0),
+                upper_bound=literal(10),
+                structure=CONSTANT,
+            ),
+        ],
+        constraints=[
+            Constraint(name="Max generation", expression=var("gen") <= var("cap"))
+        ],
+        objective_contributions={
+            "operational": (param("cost") * var("gen")).time_sum().expec()
+        },
+    )
+    database = DataBase()
+    database.add_data("P", "cost", ConstantData(1))
+    system = System("carry_over_contract")
+    system.add_component(create_component(model=plant, id="P"))
+    return Study(system, database)
+
+
+def _time_da(values: list[float]) -> xr.DataArray:
+    """Carry-over array in the shape `_extract_carry_over` produces: a `time`
+    dimension indexed 0..k-1."""
+    return xr.DataArray(
+        values, dims=["time"], coords={"time": list(range(len(values)))}
+    )
+
+
+def test_carry_over_skips_time_independent_variables() -> None:
+    """Only time-dependent variables are pinned.  A time-independent variable
+    (`structure.time = False`) is left free in every block even when the caller
+    passes a value for it, so consecutive blocks size it independently."""
+    problem = build_problem(
+        _one_time_dependent_one_constant_study(),
+        TimeBlock(1, [0, 1, 2]),
+        [0],
+        initial_values={
+            ("PLANT", "gen"): _time_da([2.0, 3.0]),
+            ("PLANT", "cap"): _time_da([7.0]),
+        },
+    )
+
+    constraint_names = set(problem.linopy_model.constraints)
+    assert "carry_over__PLANT__gen" in constraint_names
+    assert "carry_over__PLANT__cap" not in constraint_names
+
+
+def test_initial_values_without_time_dim_rejected() -> None:
+    """A value with no `time` dimension — the shape carried over before
+    multi-timestep stitching existed — is rejected outright rather than
+    silently reinterpreted as a single-timestep pin."""
+    with pytest.raises(ValueError, match="must carry a 'time' dimension"):
+        build_problem(
+            _one_time_dependent_one_constant_study(),
+            TimeBlock(1, [0, 1, 2]),
+            [0],
+            initial_values={("PLANT", "gen"): xr.DataArray(2.0)},
+        )
+
+    # The check is a precondition on the argument, so it does not need a study:
+    with pytest.raises(ValueError, match="must carry a 'time' dimension"):
+        _validate_initial_values({("PLANT", "gen"): xr.DataArray(2.0)})
+
+    assert _validate_initial_values(None) == {}


### PR DESCRIPTION
Replace the four value-comparison tests of `carry-over-length` with one parametrized test that checks what the setting actually controls: which variables are fixed by a carry-over equality constraint and which are left free.

`carry-over-length` varies as a fixture over {omitted, 0, 1, 2} with `block-overlap: 3`, and each solved block's linopy model is inspected directly: no `carry_over__*` constraint on the first block, none at all for `carry-over-length: 0`, and otherwise every carry-over constraint fixes exactly the `carry-over-length` leading local timesteps — i.e. the earliest shared timesteps — leaving the rest of the overlap zone free.

The previous tests only asserted that the pinned timesteps agreed between consecutive blocks, so none of them failed if `carry-over-length` were ignored; with `effective_carry_over_length` forced to return `block_overlap`, all three explicit cases of the new test fail.

The per-block problems are reached by running a `SimulationSession` directly and recording what `_run_block` returns, since `run_study` discards them.

