### PR TITLE
Release v0.2.0: Sequential mode improvements and refactoring

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,29 +19,18 @@ All notable changes to GemsPy are documented here.
   expression language, usable in `extra-outputs` and port-field-definitions. Both take a bare
   variable identifier and return its *current* lower/upper bound post-solve — in particular
   reflecting mutations made by thermal heuristics (see "Integer strategy and thermal
-  heuristics" above), which previously had no way to be surfaced in results. Validated at
-  model-build time; using them inside constraints, binding-constraints, objective
-  contributions, or variable bounds raises a `ValueError`.
+  heuristics" above).
 
 ### Changed
 - **Sequential mode carry-over length is now user-controlled** through the new
   `resolution.carry-over-length` parameter (default: `block-overlap`), which
   sets how many of the shared leading timesteps of block *N+1* are pinned to
-  block *N*'s already-solved values. `0` is legal and explicit (blocks overlap
-  for lag-constraint history, but nothing is pinned); validation requires
-  `0 <= carry-over-length <= block-overlap` and `0 <= block-overlap <
-  block-length`. Both `block-overlap` and `carry-over-length` are rejected
-  outside `sequential-subproblems` mode. This also fixes an incorrect stitching
+  block *N*'s already-solved values. This also fixes an incorrect stitching
   for `block-overlap >= 2`, where the previous hardcoded behaviour pinned block
   *N+1*'s first timestep to block *N*'s **last** timestep — a different
   absolute timestep.
 - **linopy upgraded to `>=0.9.0`** - the minimum supported Python version rises
   to **3.11** accordingly (linopy 0.9 requires Python >= 3.11).
-- **`validate_optim_config` moved to `gems_craft.optim_config.validation`** -
-  optim-config reading (`parsing.py`) and cross-validation (`validation.py`)
-  are now separate modules. The package-level import
-  (`from gems_craft.optim_config import validate_optim_config`) is unchanged;
-  only direct imports from `gems_craft.optim_config.parsing` need updating.
 
 ### Fixed
 - **Standard library parsing now accepts hybrid port-type fields** -

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -43,10 +43,6 @@ All notable changes to GemsPy are documented here.
   (`from gems_craft.optim_config import validate_optim_config`) is unchanged;
   only direct imports from `gems_craft.optim_config.parsing` need updating.
 
-### Removed
-- The unused `models-design/` folder (drawio diagrams), no longer referenced
-  anywhere in the codebase or the docs.
-
 ### Fixed
 - **`fast` thermal heuristic with no minimum power** - `find_min_generation_fast`
   no longer short-circuits to all-zero output when `min_power_per_unit` is ~0.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -44,13 +44,6 @@ All notable changes to GemsPy are documented here.
   only direct imports from `gems_craft.optim_config.parsing` need updating.
 
 ### Fixed
-- **`fast` thermal heuristic with no minimum power** - `find_min_generation_fast`
-  no longer short-circuits to all-zero output when `min_power_per_unit` is ~0.
-  It now always computes `num_units_on` and returns both
-  `minimum_generation_power` and `maximum_generation_power`, so unit-commitment
-  information is kept and committed units stay available for production. The
-  `fast` heuristic's declared outputs gain `maximum_generation_power`
-  accordingly.
 - **Standard library parsing now accepts hybrid port-type fields** -
   `parse_yaml_library` (the standard, non-hybrid parser) no longer rejects
   `area-connection` / `thermal-capacity-connection` on port-types, so a

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,11 +4,7 @@ All notable changes to GemsPy are documented here.
 
 ## [Unreleased]
 
-### Changed
-- **Sequential mode carry-over length can now be controlled by the user through the parameter  `carry-over-length` (default: `block-overlap`). This also fixes an incorrect stitching for `block-overlap >= 2`, where the previous hardcoded behaviour pinned block
-  *N+1*'s first timestep to block *N*'s **last** timestep — a different absolute timestep. 
-- **linopy upgraded to `>=0.9.0`** - the minimum supported Python version rises
-  to **3.11** accordingly (linopy 0.9 requires Python >= 3.11).
+## [0.2.0] - 2026-08-24
 
 ### Added
 - **Integer strategy and thermal heuristics** - components can now set
@@ -27,7 +23,38 @@ All notable changes to GemsPy are documented here.
   model-build time; using them inside constraints, binding-constraints, objective
   contributions, or variable bounds raises a `ValueError`.
 
+### Changed
+- **Sequential mode carry-over length is now user-controlled** through the new
+  `resolution.carry-over-length` parameter (default: `block-overlap`), which
+  sets how many of the shared leading timesteps of block *N+1* are pinned to
+  block *N*'s already-solved values. `0` is legal and explicit (blocks overlap
+  for lag-constraint history, but nothing is pinned); validation requires
+  `0 <= carry-over-length <= block-overlap` and `0 <= block-overlap <
+  block-length`. Both `block-overlap` and `carry-over-length` are rejected
+  outside `sequential-subproblems` mode. This also fixes an incorrect stitching
+  for `block-overlap >= 2`, where the previous hardcoded behaviour pinned block
+  *N+1*'s first timestep to block *N*'s **last** timestep — a different
+  absolute timestep.
+- **linopy upgraded to `>=0.9.0`** - the minimum supported Python version rises
+  to **3.11** accordingly (linopy 0.9 requires Python >= 3.11).
+- **`validate_optim_config` moved to `gems_craft.optim_config.validation`** -
+  optim-config reading (`parsing.py`) and cross-validation (`validation.py`)
+  are now separate modules. The package-level import
+  (`from gems_craft.optim_config import validate_optim_config`) is unchanged;
+  only direct imports from `gems_craft.optim_config.parsing` need updating.
+
+### Removed
+- The unused `models-design/` folder (drawio diagrams), no longer referenced
+  anywhere in the codebase or the docs.
+
 ### Fixed
+- **`fast` thermal heuristic with no minimum power** - `find_min_generation_fast`
+  no longer short-circuits to all-zero output when `min_power_per_unit` is ~0.
+  It now always computes `num_units_on` and returns both
+  `minimum_generation_power` and `maximum_generation_power`, so unit-commitment
+  information is kept and committed units stay available for production. The
+  `fast` heuristic's declared outputs gain `maximum_generation_power`
+  accordingly.
 - **Standard library parsing now accepts hybrid port-type fields** -
   `parse_yaml_library` (the standard, non-hybrid parser) no longer rejects
   `area-connection` / `thermal-capacity-connection` on port-types, so a
@@ -37,6 +64,8 @@ All notable changes to GemsPy are documented here.
   `HybridPortTypeSchema`) directly onto `gems_craft`'s own `PortTypeSchema`;
   the fields are parsed and validated but otherwise ignored outside hybrid
   consumers.
+
+---
 
 ## [0.1.3] - 2026-07-24
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gemspy"
-version = "0.1.3"
+version = "0.2.0"
 description = "Python interpreter for GEMS: modelling and simulation of complex energy systems under uncertainty"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -475,7 +475,7 @@ wheels = [
 
 [[package]]
 name = "gemspy"
-version = "0.1.3"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "antlr4-python3-runtime" },


### PR DESCRIPTION
## Process ID

**Process:** N/A

## Description

This PR releases version 0.2.0 with several significant improvements and refactoring:

### Key Changes

1. **Sequential mode carry-over length is now user-controlled** - Introduces a new `resolution.carry-over-length` parameter (default: `block-overlap`) that allows users to control how many shared leading timesteps of block N+1 are pinned to block N's solved values. This replaces the previous hardcoded behavior and fixes incorrect stitching for `block-overlap >= 2`.

2. **linopy upgraded to >=0.9.0** - Minimum supported Python version now rises to 3.11 accordingly.

3. **Module reorganization** - `validate_optim_config` moved from `gems_craft.optim_config.parsing` to `gems_craft.optim_config.validation`. Package-level imports remain unchanged; only direct imports from the parsing module need updating.

4. **Removed unused models-design/ folder** - Cleaned up drawio diagrams that are no longer referenced.

5. **Fixed `fast` thermal heuristic with no minimum power** - `find_min_generation_fast` no longer short-circuits to all-zero output when `min_power_per_unit` is ~0, ensuring unit-commitment information is preserved.

6. **Standard library parsing now accepts hybrid port-type fields** - `parse_yaml_library` no longer rejects `area-connection` / `thermal-capacity-connection` on port-types.

## Impact Analysis

**Modules affected:** optim_config/, simulation/ (thermal heuristics)

**Solver output changes:** The fix to sequential mode stitching may produce different results for problems using `block-overlap >= 2`, as the previous behavior was incorrect. The thermal heuristic fix ensures committed units remain available for production when minimum power is near zero.

## Checklist

- [ ] Unit tests pass (`pytest`)
- [ ] Type checking passes (`mypy`)
- [ ] Formatting passes (`black`, `isort`)
- [x] `pyproject.toml` version bumped (0.1.3 → 0.2.0)
- [ ] `AGENTS.md` reviewed for impact and updated if needed

https://claude.ai/code/session_01QwP1EdXwXBpTQdTqT7U5yP